### PR TITLE
Allow intrinsic individual importance to be measured sitewise (and residuewise)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -159,8 +159,11 @@ ENV nfolds="2"
 #   possible values are 'marg' (for marginal), 'cond' (for conditional), 'marg;cond' (for both marginal and conditional), or none (input "")
 ENV importance_grp=""
 # what individual-level importance measures should be computed?
-#   possible values are marg (for marginal), cond (for conditional), pred (for ML-specific predictive importance), a semicolon-separated combination of these three, or none (input "")
+#   possible values are 'marg' (for marginal), 'cond' (for conditional), 'pred' (for ML-specific predictive importance), a semicolon-separated combination of these three, or none (input "")
 ENV importance_ind=""
+# should individual-level intrinsic importance be measured on a site-wise or residue-wise basis?
+#   possible values are 'sitewise' or 'residuewise' (only used if importance_ind contains 'marg' or 'cond')
+Env ind_importance_type="sitewise"
 
 # set the name of the saved report
 #  if set to "", then will default to report_[_-separated list of nabs]_[date].html

--- a/code/00_utils.R
+++ b/code/00_utils.R
@@ -1050,7 +1050,7 @@ vimp_nice_group_names <- function(nm_vec = NULL) {
     return(nice_names[reference_positions])
 }
 vimp_nice_ind_names <- function(nm_vec = NULL) {
-    no_hxb2 <- gsub("hxb2.", "", nm_vec, fixed = TRUE)
+    no_hxb2 <- gsub("hxb2_", "", gsub("hxb2.", "", nm_vec, fixed = TRUE), fixed = TRUE)
     no_1mer <- gsub(".1mer", "", no_hxb2, fixed = TRUE)
     return(no_1mer)
 }

--- a/code/00_utils.R
+++ b/code/00_utils.R
@@ -20,11 +20,9 @@ get_sys_var <- function(option = "nab", boolean = FALSE){
 }
 
 # read in permanent options
-get_global_options <- function(options = c("nab", "outcomes", "learners", "cvtune", "cvperf", "nfolds", "combination_method", "binary_outcomes",
-                                           "importance_grp", "importance_ind", "report_name", "return",
-                                           "sens_thresh", "multsens_nab", "same_subset", "var_thresh"),
+get_global_options <- function(options = c("nab", "outcomes", "learners", "cvtune", "cvperf", "nfolds", "combination_method", "binary_outcomes", "importance_grp", "importance_ind", "ind_importance_type", "report_name", "return", "sens_thresh", "multsens_nab", "same_subset", "var_thresh"),
                                options_boolean = c(FALSE, FALSE, FALSE, TRUE,
-                                                   TRUE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE,
+                                                   TRUE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE,
                                                    FALSE, FALSE, TRUE, FALSE)){
     out <- mapply(option = options, boolean = options_boolean,
                   FUN = get_sys_var, SIMPLIFY = FALSE)

--- a/code/01_check_opts_functions.R
+++ b/code/01_check_opts_functions.R
@@ -64,10 +64,12 @@ check_opts_nfolds <- function(nfolds_str) {
     )
 }
 # check vimp
-check_opts_vimp <- function(grp_str, ind_str, all_grp, all_ind) {
+check_opts_vimp <- function(grp_str, ind_str, ind_type, all_grp, all_ind, all_types) {
     shiny::validate(
         shiny::need(length(setdiff(grp_str, all_grp)) == 0 | grp_str == "", "Please enter either a semicolon-separated list of supported group importance types (i.e., 'marg', 'cond', or 'marg;cond') or an empty string ('')."),
-        shiny::need(length(setdiff(ind_str, all_ind)) == 0 | ind_str == "", "Please enter either a semicolon-separated list of supported individual importance types (i.e., 'marg', 'cond', 'pred', or, e.g., 'marg;cond;pred') or an empty string ('').")
+        shiny::need(length(setdiff(ind_str, all_ind)) == 0 | ind_str == "", "Please enter either a semicolon-separated list of supported individual importance types (i.e., 'marg', 'cond', 'pred', or, e.g., 'marg;cond;pred') or an empty string ('')."),
+        shiny::need(length(setdiff(ind_type, all_types)) == 0 | ind_type == "",
+        "Please enter either a supported individual-level intrinsic importance type (i.e., 'sitewise' or 'residuewise') or an empty string ('').")
     )
 }
 # check object returns
@@ -118,7 +120,8 @@ get_options_check <- function(opts) {
     # check importance
     all_importance_grp <- c("marg", "cond")
     all_importance_ind <- c("marg", "cond", "pred")
-    check_opts_vimp(opts$importance_grp, opts$importance_ind, all_importance_grp, all_importance_ind)
+    all_ind_types <- c("sitewise", "residuewise")
+    check_opts_vimp(opts$importance_grp, opts$importance_ind, opts$ind_importance_type, all_importance_grp, all_importance_ind, all_ind_types)
     # check objects requested for return
     all_returns <- c("report", "data", "learner", "figures", "vimp")
     check_opts_returns(opts$return, all_returns)

--- a/code/03_run_super_learners.R
+++ b/code/03_run_super_learners.R
@@ -119,7 +119,7 @@ ind_sl_lib <- switch(
 # (3) If "marg" is in opts$importance_grp, run regression of each outcome in outcome_names on the set of features defined by the group of interest + confounders
 # (4) If "marg" is in opts$importance_grp, run regression of each outcome in outcome_names on geographic confounders only
 # ----------------------------------------------------------------------------
-if (("cond" %in% opts$importance_grp) | ("marg" %in% opts$importance_grp | ("marg" %in% opts$importance_ind & grepl("site", opts$ind_importance_type)))) {
+if (("cond" %in% opts$importance_grp) | ("marg" %in% opts$importance_grp | "marg" %in% opts$importance_ind)) {
     for (i in 1:length(outcome_names)) {
         set.seed(4747)
         this_outcome_name <- outcome_names[i]

--- a/code/04_get_vimp.R
+++ b/code/04_get_vimp.R
@@ -101,7 +101,7 @@ if (((length(opts$importance_grp) == 0) & (length(opts$importance_ind) == 0))) {
                 if ((length(opts$learners) == 1 & opts$cvtune & opts$cvperf) | (length(opts$learners) > 1 & opts$cvperf)) {
                     geog_glm_cv_fit <- readRDS(paste0("/home/slfits/cvfitted_", this_outcome_name, "_geog_glm.rds"))
                     geog_glm_cv_folds <- readRDS(paste0("/home/slfits/cvfolds_", this_outcome_name, "_geog_glm.rds"))
-                    geog_glm_cv_folds_vec <- get_cv_folds(geog_cv_folds)
+                    geog_glm_cv_folds_vec <- get_cv_folds(geog_glm_cv_folds)
                     geog_glm_cv_fit_lst <- lapply(as.list(1:length(unique(geog_glm_cv_folds_vec))), function(x) geog_glm_cv_fit[geog_glm_cv_folds_vec == x])
                 }
             }

--- a/code/04_get_vimp.R
+++ b/code/04_get_vimp.R
@@ -1,8 +1,8 @@
 #! /usr/bin/env Rscript
 
-## ---------------------------------------------------------------------------
-## Set up args, variables, functions
-## ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# Set up args, variables, functions
+# ---------------------------------------------------------------------------
 
 # load libraries
 library("SuperLearner")
@@ -36,8 +36,9 @@ outcome_names <- get_outcome_names(opts)
 # get variable groups
 all_var_groups <- get_variable_groups(complete_dat, pred_names)
 all_geog_vars <- pred_names[grepl("geog", pred_names)]
+# get individual variables -- either sitewise or residuewise
 num_covs <- length(pred_names) - length(all_geog_vars)
-var_inds <- pred_names[!grepl("geog", pred_names)][1:num_covs]
+var_inds <- get_individual_features(pred_names[!grepl("geog", pred_names)][1:num_covs], opts$ind_importance_type)
 
 # set number of CV folds
 V <- as.numeric(opts$nfolds)
@@ -47,9 +48,9 @@ run_sl_vimp_bools <- check_outcomes(complete_dat, outcome_names, V)
 run_sl_vimp_bools2 <- lapply(run_sl_vimp_bools, function(x){
     x[c("ic50", "ic80", "iip", "sens1", "sens2") %in% opts$outcomes]
 })
-## ---------------------------------------------------------------------------
-## get variable importance! but only run if one of opts$importance_grp or opts$importance_ind is not empty
-## ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# get variable importance! but only run if one of opts$importance_grp or opts$importance_ind is not empty
+# ---------------------------------------------------------------------------
 set.seed(474747)
 # if none of them, then don't run variable importance
 if (((length(opts$importance_grp) == 0) & (length(opts$importance_ind) == 0))) {
@@ -66,14 +67,14 @@ if (((length(opts$importance_grp) == 0) & (length(opts$importance_ind) == 0))) {
         }
         dat <- complete_dat[complete_cases_idx, ]
         if (run_sl_vimp_bools2$run_vimp[i]) {
-            ## create output list
+            # create output list
             eval(parse(text = paste0(this_outcome_name, '_vimp_lst <- make_vimp_list(all_var_groups, var_inds)')))
             eval(parse(text = paste0(this_outcome_name, '_cv_vimp_lst <- make_vimp_list(all_var_groups, var_inds)')))
-            ## load in outer folds for VIM
+            # load in outer folds for VIM
             outer_folds <- readRDS(paste0("/home/slfits/", this_outcome_name, "_outer_folds.rds"))
-            ## if "cond" is in either opts$importance_grp or opts$importance_ind, read it in
+            # if "cond" is in either opts$importance_grp or opts$importance_ind, read it in
             if (("cond" %in% opts$importance_grp) | ("cond" %in% opts$importance_ind)) {
-                ## load full fit corresponding to this outcome
+                # load full fit corresponding to this outcome
                 full_fit <- readRDS(paste0("/home/slfits/fitted_", this_outcome_name, "_for_vimp.rds"))
                 if ((length(opts$learners) == 1 & opts$cvtune & opts$cvperf) | (length(opts$learners) > 1 & opts$cvperf)) {
                     full_cv_fit <- readRDS(paste0("/home/slfits/cvfitted_", this_outcome_name, "_for_vimp.rds"))
@@ -82,9 +83,9 @@ if (((length(opts$importance_grp) == 0) & (length(opts$importance_ind) == 0))) {
                     full_cv_fit_lst <- lapply(as.list(1:length(unique(full_cv_folds_vec))), function(x) full_cv_fit[full_cv_folds_vec == x])
                 }
             }
-            # if "marg" is in opts$importance_grp, read in the "sl" fit with geographic confounders only
-            if (("marg" %in% opts$importance_grp)) {
-                ## load geog-only fit corresponding to this outcome
+            # if "marg" is in opts$importance_grp, read in the fit with geographic confounders only
+            if (("marg" %in% opts$importance_grp) | ("marg" %in% opts$importance_ind & grepl("site", opts$ind_importance_type))) {
+                # load geog-only fit corresponding to this outcome
                 geog_fit <- readRDS(paste0("/home/slfits/fitted_", this_outcome_name, "_geog.rds"))
                 if ((length(opts$learners) == 1 & opts$cvtune & opts$cvperf) | (length(opts$learners) > 1 & opts$cvperf)) {
                     geog_cv_fit <- readRDS(paste0("/home/slfits/cvfitted_", this_outcome_name, "_geog.rds"))
@@ -93,9 +94,9 @@ if (((length(opts$importance_grp) == 0) & (length(opts$importance_ind) == 0))) {
                     geog_cv_fit_lst <- lapply(as.list(1:length(unique(geog_cv_folds_vec))), function(x) geog_cv_fit[geog_cv_folds_vec == x])
                 }
             }
-            # if "marg" is in opts$importance_ind, read in the glm fit with geographic confounders only
-            if (("marg" %in% opts$importance_ind)) {
-                ## load geog-only fit corresponding to this outcome
+            # if "marg" is in opts$importance_ind, read in the fit with geographic confounders only
+            if (("marg" %in% opts$importance_ind) & grepl("residue", opts$ind_importance_type)) {
+                # load geog-only fit corresponding to this outcome
                 geog_glm_fit <- readRDS(paste0("/home/slfits/fitted_", this_outcome_name, "_geog_glm.rds"))
                 if ((length(opts$learners) == 1 & opts$cvtune & opts$cvperf) | (length(opts$learners) > 1 & opts$cvperf)) {
                     geog_glm_cv_fit <- readRDS(paste0("/home/slfits/cvfitted_", this_outcome_name, "_geog_glm.rds"))
@@ -104,16 +105,16 @@ if (((length(opts$importance_grp) == 0) & (length(opts$importance_ind) == 0))) {
                     geog_glm_cv_fit_lst <- lapply(as.list(1:length(unique(geog_glm_cv_folds_vec))), function(x) geog_glm_cv_fit[geog_glm_cv_folds_vec == x])
                 }
             }
-            ## -----------------------------------
-            ## group variable importance
-            ## -----------------------------------
-            ## if "cond" is in opts$importance_grp, run this loop
+            # -----------------------------------
+            # group variable importance
+            # -----------------------------------
+            # if "cond" is in opts$importance_grp, run this loop
             if ("cond" %in% opts$importance_grp) {
                 for (j in 1:length(all_var_groups)) {
                     this_group_name <- names(all_var_groups)[j]
                     cond_fit <- readRDS(paste0("/home/slfits/fitted_", this_outcome_name, "_conditional_", this_group_name, ".rds"))
                     cond_folds <- list(outer_folds = outer_folds)
-                    ## get conditional, non-cv vimp
+                    # get conditional, non-cv vimp
                     suppressWarnings(eval(parse(text = paste0(this_outcome_name, "_cond_", this_group_name, " <- vimp::vim(Y = dat[, this_outcome_name], f1 = full_fit, f2 = cond_fit, indx = which(pred_names %in% all_var_groups[[j]]), run_regression = FALSE, alpha = 0.05, delta = 0, type = vimp_opts$vimp_measure, folds = cond_folds$outer_folds, na.rm = TRUE, scale = 'identity')"))))
                     if ((length(opts$learners) == 1 & opts$cvtune & opts$cvperf) | (length(opts$learners) > 1 & opts$cvperf)) {
                         cond_cv_fit <- readRDS(paste0("/home/slfits/cvfitted_", this_outcome_name, "_conditional_", this_group_name, ".rds"))
@@ -121,23 +122,23 @@ if (((length(opts$importance_grp) == 0) & (length(opts$importance_ind) == 0))) {
                         cond_cv_folds_vec <- get_cv_folds(cond_cv_folds)
                         cond_cv_fit_lst <- lapply(as.list(1:length(unique(cond_cv_folds_vec))), function(x) cond_cv_fit[cond_cv_folds_vec == x])
                         cond_folds <- list(outer_folds = outer_folds, inner_folds = list(inner_folds_1 = full_cv_folds_vec, inner_folds_2 = cond_cv_folds_vec))
-                        ## get conditional, cv vimp
+                        # get conditional, cv vimp
                         suppressWarnings(eval(parse(text = paste0(this_outcome_name, "_cv_cond_", this_group_name, " <- vimp::cv_vim(Y = dat[, this_outcome_name], f1 = full_cv_fit_lst, f2 = cond_cv_fit_lst, indx = which(pred_names %in% all_var_groups[[j]]), run_regression = FALSE, alpha = 0.05, delta = 0, type = vimp_opts$vimp_measure, folds = cond_folds, V = V, na.rm = TRUE, scale = 'identity')"))))
                     }
                 }
-                ## merge together
+                # merge together
                 eval(parse(text = paste0(this_outcome_name, "_vimp_lst$grp_conditional <- merge_vim(", paste(paste0(this_outcome_name, "_cond_", names(all_var_groups)), collapse = ", "), ")")))
                 if ((length(opts$learners) == 1 & opts$cvtune & opts$cvperf) | (length(opts$learners) > 1 & opts$cvperf)) {
                     eval(parse(text = paste0(this_outcome_name, "_cv_vimp_lst$grp_conditional <- merge_vim(", paste(paste0(this_outcome_name, "_cv_cond_", names(all_var_groups)), collapse = ", "), ")")))
                 }
             }
-            ## if "marg" is in opts$importance_grp, run this loop
+            # if "marg" is in opts$importance_grp, run this loop
             if ("marg" %in% opts$importance_grp) {
                 for (j in 1:length(all_var_groups)) {
                     this_group_name <- names(all_var_groups)[j]
                     marg_fit <- readRDS(paste0("/home/slfits/fitted_", this_outcome_name, "_marginal_", this_group_name, ".rds"))
                     marg_folds <- list(outer_folds = (-1) * (outer_folds - 1) + 2)
-                    ## get marginal, non-cv vimp
+                    # get marginal, non-cv vimp
                     suppressWarnings(eval(parse(text = paste0(this_outcome_name, "_marg_", this_group_name, " <- vimp::vim(Y = dat[, this_outcome_name], f1 = marg_fit, f2 = geog_fit, indx = which(pred_names %in% all_var_groups[[j]]), run_regression = FALSE, alpha = 0.05, delta = 0, type = vimp_opts$vimp_measure, folds = marg_folds$outer_folds, na.rm = TRUE, scale = 'identity')"))))
                     if ((length(opts$learners) == 1 & opts$cvtune & opts$cvperf) | (length(opts$learners) > 1 & opts$cvperf)) {
                         marg_cv_fit <- readRDS(paste0("/home/slfits/cvfitted_", this_outcome_name, "_marginal_", this_group_name, ".rds"))
@@ -145,69 +146,82 @@ if (((length(opts$importance_grp) == 0) & (length(opts$importance_ind) == 0))) {
                         marg_cv_folds_vec <- get_cv_folds(marg_cv_folds)
                         marg_cv_fit_lst <- lapply(as.list(1:length(unique(marg_cv_folds_vec))), function(x) marg_cv_fit[marg_cv_folds_vec == x])
                         marg_folds <- list(outer_folds = (-1) * (outer_folds - 1) + 2, inner_folds = list(inner_folds_1 = marg_cv_folds_vec, inner_folds_2 = geog_cv_folds_vec))
-                        ## get marginal, cv vimp
+                        # get marginal, cv vimp
                         suppressWarnings(eval(parse(text = paste0(this_outcome_name, "_cv_marg_", this_group_name, " <- vimp::cv_vim(Y = dat[, this_outcome_name], f1 = marg_cv_fit_lst, f2 = geog_cv_fit_lst, indx = which(pred_names %in% all_var_groups[[j]]), run_regression = FALSE, alpha = 0.05, delta = 0, type = vimp_opts$vimp_measure, folds = marg_folds, V = V, na.rm = TRUE, scale = 'identity')"))))
                     }
                 }
-                ## merge together
+                # merge together
                 eval(parse(text = paste0(this_outcome_name, "_vimp_lst$grp_marginal <- merge_vim(", paste(paste0(this_outcome_name, "_marg_", names(all_var_groups)), collapse = ", "), ")")))
                 if ((length(opts$learners) == 1 & opts$cvtune & opts$cvperf) | (length(opts$learners) > 1 & opts$cvperf)) {
                     eval(parse(text = paste0(this_outcome_name, "_cv_vimp_lst$grp_marginal <- merge_vim(", paste(paste0(this_outcome_name, "_cv_marg_", names(all_var_groups)), collapse = ", "), ")")))
                 }
             }
-            ## -----------------------------------
-            ## individual variable importance
-            ## -----------------------------------
-            ## if "cond" is in opts$importance_ind, run this loop
+            # -----------------------------------
+            # individual variable importance
+            # -----------------------------------
+            # if "cond" is in opts$importance_ind, run this loop
             if ("cond" %in% opts$importance_ind) {
                 for (j in 1:length(var_inds)) {
-                    this_var_name <- var_inds[j]
+                    this_var_name <- names(var_inds)[j]
                     indi_cond_fit <- readRDS(paste0("/home/slfits/fitted_", this_outcome_name, "_conditional_", this_var_name, ".rds"))
                     indi_cond_folds <- list(outer_folds = outer_folds)
-                    ## get individual, non-cv vimp
-                    suppressWarnings(eval(parse(text = paste0(this_outcome_name, "_cond_", this_var_name, " <- vimp::vim(Y = dat[, this_outcome_name], f1 = full_fit, f2 = indi_cond_fit, indx = which(pred_names %in% this_var_name), run_regression = FALSE, alpha = 0.05, delta = 0, type = vimp_opts$vimp_measure, folds = indi_cond_folds$outer_folds, na.rm = TRUE, scale = 'identity')"))))
+                    # get individual, non-cv vimp
+                    suppressWarnings(eval(parse(text = paste0(this_outcome_name, "_cond_", this_var_name, " <- vimp::vim(Y = dat[, this_outcome_name], f1 = full_fit, f2 = indi_cond_fit, indx = which(pred_names %in% var_inds[[j]]), run_regression = FALSE, alpha = 0.05, delta = 0, type = vimp_opts$vimp_measure, folds = indi_cond_folds$outer_folds, na.rm = TRUE, scale = 'identity')"))))
                     if ((length(opts$learners) == 1 & opts$cvtune & opts$cvperf) | (length(opts$learners) > 1 & opts$cvperf)) {
                         indi_cv_cond_fit <- readRDS(paste0("/home/slfits/cvfitted_", this_outcome_name, "_conditional_", this_var_name, ".rds"))
                         indi_cv_cond_folds <- readRDS(paste0("/home/slfits/cvfolds_", this_outcome_name, "_conditional_", this_var_name, ".rds"))
                         indi_cv_cond_folds_vec <- get_cv_folds(indi_cv_cond_folds)
                         indi_cv_cond_fit_lst <- lapply(as.list(1:length(unique(indi_cv_cond_folds_vec))), function(x) indi_cv_cond_fit[indi_cv_cond_folds_vec == x])
                         indi_cond_folds <- list(outer_folds = outer_folds, inner_folds = list(inner_folds_1 = full_cv_folds_vec, inner_folds_2 = indi_cv_cond_folds_vec))
-                        ## get individual, cv vimp
-                        suppressWarnings(eval(parse(text = paste0(this_outcome_name, "_cv_cond_", this_var_name, " <- vimp::cv_vim(Y = dat[, this_outcome_name], f1 = full_cv_fit_lst, f2 = indi_cv_cond_fit_lst, indx = which(pred_names %in% this_var_name), run_regression = FALSE, alpha = 0.05, delta = 0, type = vimp_opts$vimp_measure, folds = indi_cond_folds, V = V, na.rm = TRUE, scale = 'identity')"))))
+                        # get individual, cv vimp
+                        suppressWarnings(eval(parse(text = paste0(this_outcome_name, "_cv_cond_", this_var_name, " <- vimp::cv_vim(Y = dat[, this_outcome_name], f1 = full_cv_fit_lst, f2 = indi_cv_cond_fit_lst, indx = which(pred_names %in% var_inds[[j]]), run_regression = FALSE, alpha = 0.05, delta = 0, type = vimp_opts$vimp_measure, folds = indi_cond_folds, V = V, na.rm = TRUE, scale = 'identity')"))))
                     }
                 }
-                ## merge together
+                # merge together
                 eval(parse(text = paste0(this_outcome_name, "_vimp_lst$ind_conditional <- merge_vim(", paste(paste0(this_outcome_name, "_cond_", var_inds), collapse = ", "), ")")))
                 if ((length(opts$learners) == 1 & opts$cvtune & opts$cvperf) | (length(opts$learners) > 1 & opts$cvperf)) {
                     eval(parse(text = paste0(this_outcome_name, "_cv_vimp_lst$ind_conditional <- merge_vim(", paste(paste0(this_outcome_name, "_cv_cond_", var_inds), collapse = ", "), ")")))
                 }
             }
-            ## if "marg" is in opts$importance_ind, run this loop
+            # if "marg" is in opts$importance_ind, run this loop
             if ("marg" %in% opts$importance_ind) {
+                if (grepl("residue", opts$importance_type)) {
+                    reduced_fit <- geog_glm_fit
+                    reduced_cv_fit <- geog_glm_cv_fit
+                    reduced_cv_folds <- geog_glm_cv_folds
+                    reduced_cv_folds_vec <- geog_glm_cv_folds_vec
+                    reduced_cv_fit_lst <- geog_glm_cv_fit_lst
+                } else {
+                    reduced_fit <- geog_fit
+                    reduced_cv_fit <- geog_cv_fit
+                    reduced_cv_folds <- geog_cv_folds
+                    reduced_cv_folds_vec <- geog_cv_folds_vec
+                    reduced_cv_fit_lst <- geog_cv_fit_lst
+                }
                 for (j in 1:length(var_inds)) {
-                    this_var_name <- var_inds[j]
+                    this_var_name <- names(var_inds)[j]
                     indi_marg_fit <- readRDS(paste0("/home/slfits/fitted_", this_outcome_name, "_marginal_", this_var_name, ".rds"))
                     indi_marg_folds <- list(outer_folds = (-1) * (outer_folds - 1) + 2)
-                    ## get individual, non-cv vimp
-                    suppressWarnings(eval(parse(text = paste0(this_outcome_name, "_marg_", this_var_name, " <- vimp::vim(Y = dat[, this_outcome_name], f1 = indi_marg_fit, f2 = geog_glm_fit, indx = which(pred_names %in% this_var_name), run_regression = FALSE, alpha = 0.05, delta = 0, type = vimp_opts$vimp_measure, folds = indi_marg_folds$outer_folds, na.rm = TRUE, scale = 'identity')"))))
+                    # get individual, non-cv vimp
+                    suppressWarnings(eval(parse(text = paste0(this_outcome_name, "_marg_", this_var_name, " <- vimp::vim(Y = dat[, this_outcome_name], f1 = indi_marg_fit, f2 = reduced_fit, indx = which(pred_names %in% this_var_name), run_regression = FALSE, alpha = 0.05, delta = 0, type = vimp_opts$vimp_measure, folds = indi_marg_folds$outer_folds, na.rm = TRUE, scale = 'identity')"))))
                     if ((length(opts$learners) == 1 & opts$cvtune & opts$cvperf) | (length(opts$learners) > 1 & opts$cvperf)) {
-                        ## cv
+                        # cv
                         indi_cv_marg_fit <- readRDS(paste0("/home/slfits/cvfitted_", this_outcome_name, "_marginal_", this_var_name, ".rds"))
                         indi_cv_marg_folds <- readRDS(paste0("/home/slfits/cvfolds_", this_outcome_name, "_marginal_", this_var_name, ".rds"))
                         indi_cv_marg_folds_vec <- get_cv_folds(indi_cv_marg_folds)
                         indi_cv_marg_fit_lst <- lapply(as.list(1:length(unique(indi_cv_marg_folds_vec))), function(x) indi_cv_marg_fit[indi_cv_marg_folds_vec == x])
-                        indi_marg_folds <- list(outer_folds = (-1) * (outer_folds - 1) + 2, inner_folds = list(inner_folds_1 = indi_cv_marg_folds_vec, inner_folds_2 = geog_glm_cv_folds_vec))
-                        ## get individual, cv vimp
-                        suppressWarnings(eval(parse(text = paste0(this_outcome_name, "_cv_marg_", this_var_name, " <- vimp::cv_vim(Y = dat[, this_outcome_name], f1 = indi_cv_marg_fit_lst, f2 = geog_glm_cv_fit_lst, indx = which(pred_names %in% this_var_name), run_regression = FALSE, alpha = 0.05, delta = 0, type = vimp_opts$vimp_measure, folds = indi_marg_folds, V = V, na.rm = TRUE, scale = 'identity')"))))
+                        indi_marg_folds <- list(outer_folds = (-1) * (outer_folds - 1) + 2, inner_folds = list(inner_folds_1 = indi_cv_marg_folds_vec, inner_folds_2 = reduced_cv_folds_vec))
+                        # get individual, cv vimp
+                        suppressWarnings(eval(parse(text = paste0(this_outcome_name, "_cv_marg_", this_var_name, " <- vimp::cv_vim(Y = dat[, this_outcome_name], f1 = indi_cv_marg_fit_lst, f2 = reduced_cv_fit_lst, indx = which(pred_names %in% this_var_name), run_regression = FALSE, alpha = 0.05, delta = 0, type = vimp_opts$vimp_measure, folds = indi_marg_folds, V = V, na.rm = TRUE, scale = 'identity')"))))
                     }
                 }
-                ## merge together
+                # merge together
                 eval(parse(text = paste0(this_outcome_name, "_vimp_lst$ind_marginal <- merge_vim(", paste(paste0(this_outcome_name, "_marg_", var_inds), collapse = ", "), ")")))
                 if ((length(opts$learners) == 1 & opts$cvtune & opts$cvperf) | (length(opts$learners) > 1 & opts$cvperf)) {
                     eval(parse(text = paste0(this_outcome_name, "_cv_vimp_lst$ind_marginal <- merge_vim(", paste(paste0(this_outcome_name, "_cv_marg_", var_inds), collapse = ", "), ")")))
                 }
             }
-            ## save them off
+            # save them off
             eval(parse(text = paste0("saveRDS(", this_outcome_name, "_vimp_lst, file = '/home/slfits/", paste0(this_outcome_name, "_vimp"), ".rds')")))
             eval(parse(text = paste0("saveRDS(", this_outcome_name, "_cv_vimp_lst, file = '/home/slfits/", paste0(this_outcome_name, "_cv_vimp"), ".rds')")))
         }

--- a/code/04_get_vimp.R
+++ b/code/04_get_vimp.R
@@ -178,14 +178,14 @@ if (((length(opts$importance_grp) == 0) & (length(opts$importance_ind) == 0))) {
                     }
                 }
                 # merge together
-                eval(parse(text = paste0(this_outcome_name, "_vimp_lst$ind_conditional <- merge_vim(", paste(paste0(this_outcome_name, "_cond_", var_inds), collapse = ", "), ")")))
+                eval(parse(text = paste0(this_outcome_name, "_vimp_lst$ind_conditional <- merge_vim(", paste(paste0(this_outcome_name, "_cond_", names(var_inds)), collapse = ", "), ")")))
                 if ((length(opts$learners) == 1 & opts$cvtune & opts$cvperf) | (length(opts$learners) > 1 & opts$cvperf)) {
-                    eval(parse(text = paste0(this_outcome_name, "_cv_vimp_lst$ind_conditional <- merge_vim(", paste(paste0(this_outcome_name, "_cv_cond_", var_inds), collapse = ", "), ")")))
+                    eval(parse(text = paste0(this_outcome_name, "_cv_vimp_lst$ind_conditional <- merge_vim(", paste(paste0(this_outcome_name, "_cv_cond_", names(var_inds)), collapse = ", "), ")")))
                 }
             }
             # if "marg" is in opts$importance_ind, run this loop
             if ("marg" %in% opts$importance_ind) {
-                if (grepl("residue", opts$importance_type)) {
+                if (grepl("residue", opts$ind_importance_type)) {
                     reduced_fit <- geog_glm_fit
                     reduced_cv_fit <- geog_glm_cv_fit
                     reduced_cv_folds <- geog_glm_cv_folds
@@ -203,7 +203,7 @@ if (((length(opts$importance_grp) == 0) & (length(opts$importance_ind) == 0))) {
                     indi_marg_fit <- readRDS(paste0("/home/slfits/fitted_", this_outcome_name, "_marginal_", this_var_name, ".rds"))
                     indi_marg_folds <- list(outer_folds = (-1) * (outer_folds - 1) + 2)
                     # get individual, non-cv vimp
-                    suppressWarnings(eval(parse(text = paste0(this_outcome_name, "_marg_", this_var_name, " <- vimp::vim(Y = dat[, this_outcome_name], f1 = indi_marg_fit, f2 = reduced_fit, indx = which(pred_names %in% this_var_name), run_regression = FALSE, alpha = 0.05, delta = 0, type = vimp_opts$vimp_measure, folds = indi_marg_folds$outer_folds, na.rm = TRUE, scale = 'identity')"))))
+                    suppressWarnings(eval(parse(text = paste0(this_outcome_name, "_marg_", this_var_name, " <- vimp::vim(Y = dat[, this_outcome_name], f1 = indi_marg_fit, f2 = reduced_fit, indx = which(pred_names %in% var_inds[[j]]), run_regression = FALSE, alpha = 0.05, delta = 0, type = vimp_opts$vimp_measure, folds = indi_marg_folds$outer_folds, na.rm = TRUE, scale = 'identity')"))))
                     if ((length(opts$learners) == 1 & opts$cvtune & opts$cvperf) | (length(opts$learners) > 1 & opts$cvperf)) {
                         # cv
                         indi_cv_marg_fit <- readRDS(paste0("/home/slfits/cvfitted_", this_outcome_name, "_marginal_", this_var_name, ".rds"))
@@ -212,13 +212,13 @@ if (((length(opts$importance_grp) == 0) & (length(opts$importance_ind) == 0))) {
                         indi_cv_marg_fit_lst <- lapply(as.list(1:length(unique(indi_cv_marg_folds_vec))), function(x) indi_cv_marg_fit[indi_cv_marg_folds_vec == x])
                         indi_marg_folds <- list(outer_folds = (-1) * (outer_folds - 1) + 2, inner_folds = list(inner_folds_1 = indi_cv_marg_folds_vec, inner_folds_2 = reduced_cv_folds_vec))
                         # get individual, cv vimp
-                        suppressWarnings(eval(parse(text = paste0(this_outcome_name, "_cv_marg_", this_var_name, " <- vimp::cv_vim(Y = dat[, this_outcome_name], f1 = indi_cv_marg_fit_lst, f2 = reduced_cv_fit_lst, indx = which(pred_names %in% this_var_name), run_regression = FALSE, alpha = 0.05, delta = 0, type = vimp_opts$vimp_measure, folds = indi_marg_folds, V = V, na.rm = TRUE, scale = 'identity')"))))
+                        suppressWarnings(eval(parse(text = paste0(this_outcome_name, "_cv_marg_", this_var_name, " <- vimp::cv_vim(Y = dat[, this_outcome_name], f1 = indi_cv_marg_fit_lst, f2 = reduced_cv_fit_lst, indx = which(pred_names %in% var_inds[[j]]), run_regression = FALSE, alpha = 0.05, delta = 0, type = vimp_opts$vimp_measure, folds = indi_marg_folds, V = V, na.rm = TRUE, scale = 'identity')"))))
                     }
                 }
                 # merge together
-                eval(parse(text = paste0(this_outcome_name, "_vimp_lst$ind_marginal <- merge_vim(", paste(paste0(this_outcome_name, "_marg_", var_inds), collapse = ", "), ")")))
+                eval(parse(text = paste0(this_outcome_name, "_vimp_lst$ind_marginal <- merge_vim(", paste(paste0(this_outcome_name, "_marg_", names(var_inds)), collapse = ", "), ")")))
                 if ((length(opts$learners) == 1 & opts$cvtune & opts$cvperf) | (length(opts$learners) > 1 & opts$cvperf)) {
-                    eval(parse(text = paste0(this_outcome_name, "_cv_vimp_lst$ind_marginal <- merge_vim(", paste(paste0(this_outcome_name, "_cv_marg_", var_inds), collapse = ", "), ")")))
+                    eval(parse(text = paste0(this_outcome_name, "_cv_vimp_lst$ind_marginal <- merge_vim(", paste(paste0(this_outcome_name, "_cv_marg_", names(var_inds)), collapse = ", "), ")")))
                 }
             }
             # save them off

--- a/code/04_variable_groups.R
+++ b/code/04_variable_groups.R
@@ -38,18 +38,25 @@ get_variable_groups <- function(data, pred_names) {
 get_individual_features <- function(pred_names, ind_importance_type) {
     if (grepl("site", ind_importance_type)) {
         no_hxb2 <- gsub(".1mer", "", gsub("hxb2.", "", pred_names))
-        sites <- unique(unlist(lapply(
-            strsplit(no_hxb2, ".", fixed = TRUE),
-            function(x) x[[1]]
-        )))
-        lst <- sapply(
+        non_site_vars <- pred_names[!grepl("hxb2", pred_names)]
+        site_vars <- no_hxb2[grepl("hxb2", pred_names)]
+        sites <- sort(as.numeric(unique(unlist(lapply(
+            strsplit(site_vars, ".", fixed = TRUE),
+            function(x) x[1]
+        )))))
+        site_lst <- sapply(
             1:length(sites),
             function(i) {
-                pred_names[grepl(sites[i], pred_names)]
+                pred_names[grepl(
+                    paste0("hxb2.", sites[i], "."), pred_names, fixed = TRUE
+                )]
             }, simplify = FALSE
         )
+        lst <- c(as.list(non_site_vars), site_lst)
+        names(lst) <- c(non_site_vars, paste0("hxb2_", sites))
     } else {
         lst <- as.list(pred_names)
+        names(lst) <- pred_names
     }
     lst
 }

--- a/code/04_variable_groups.R
+++ b/code/04_variable_groups.R
@@ -1,24 +1,24 @@
-## define variable groups for importance
+# define variable groups for importance
 
-## function to set a variable group
+# function to set a variable group
 get_variable_group <- function(pred_names, hxb2_sites) {
-    ## get only the sites from the pred_names vector
+    # get only the sites from the pred_names vector
     aa_positions <- unlist(lapply(strsplit(pred_names, ".", fixed = TRUE), function(x) x[2]))
 
-    ## get the ones matching the input sites
+    # get the ones matching the input sites
     site_character_vars <- pred_names[aa_positions %in% hxb2_sites]
     return(site_character_vars)
 }
 
 get_variable_groups <- function(data, pred_names) {
-    ## set up sites
-    ## CD4bs is feature group 2 from VRC01 paper plus additional sites identified by Adam
+    # set up sites
+    # CD4bs is feature group 2 from VRC01 paper plus additional sites identified by Adam
     gp120_cd4bs <- unique(c(c(124, 125, 126, 127, 196, 198, 279, 280, 281, 282, 283, 365, 366, 367, 368, 369, 370, 374, 425, 426, 427, 428, 429, 430, 431, 432, 455, 456, 457, 458, 459, 460, 461, 469, 471, 472, 473, 474, 475, 476, 477), c(197, 209, 279, 326, 369, 119, 120, 182, 204, 206, 207, 274, 304, 318, 369, 471), c(62, 64, 66, 207), c(61, 64, 197, 276, 362, 363, 386, 392, 462, 463)))
     gp120_v2_v2g_v2apex <- unique(c(157:196, c(121, 123, 124, 127, 197, 202, 203, 312, 315)))
     gp120_v3_v3g <- unique(c(296:334), c(380, 406, 408, 415, 419, 428, 441, 443, 471), c(156, 137))
     gp41_mper <- c(656:684, 609)
 
-    ## get all variable groups
+    # get all variable groups
     aa_gp120_cd4bs_vars <- get_variable_group(pred_names, gp120_cd4bs)
     aa_gp120_v2_vars <- get_variable_group(pred_names, gp120_v2_v2g_v2apex)
     aa_gp120_v3_vars <- get_variable_group(pred_names, gp120_v3_v3g)
@@ -30,4 +30,26 @@ get_variable_groups <- function(data, pred_names) {
                 gp120_v3 = aa_gp120_v3_vars, gp41_mper = aa_gp41_mper_vars,
                 glyco = aa_glyco_vars, cysteines = aa_cysteine_vars,
                 geometry = aa_geometry_vars))
+}
+
+# get individual intrinsic importance groups
+# @param pred_names the variable names to use
+# @param ind_importance_type the type of individual importance
+get_individual_features <- function(pred_names, ind_importance_type) {
+    if (grepl("site", ind_importance_type)) {
+        no_hxb2 <- gsub(".1mer", "", gsub("hxb2.", "", pred_names))
+        sites <- unique(unlist(lapply(
+            strsplit(no_hxb2, ".", fixed = TRUE),
+            function(x) x[[1]]
+        )))
+        lst <- sapply(
+            1:length(sites),
+            function(i) {
+                pred_names[grepl(sites[i], pred_names)]
+            }, simplify = FALSE
+        )
+    } else {
+        lst <- as.list(pred_names)
+    }
+    lst
 }

--- a/code/05_report.Rmd
+++ b/code/05_report.Rmd
@@ -266,7 +266,7 @@ if ("figures" %in% opts$return) {
 
 `r if (!("ic50" %in% opts$outcomes) | (!("marg" %in% opts$importance_ind) & !("cond" %in% opts$importance_ind))) "<!--"`
 
-We show the intrinsic variable importance of individual features in predicting `r ifelse(length(opts$nab) == 1, "", "estimated")` IC$_{50}$ in Figure \@ref(fig:ic50indivimp). Importance is defined using the difference in $R^2$ values.
+We show the intrinsic variable importance of individual `r ind_import_txt` in predicting `r ifelse(length(opts$nab) == 1, "", "estimated")` IC$_{50}$ in Figure \@ref(fig:ic50indivimp). Importance is defined using the difference in $R^2$ values.
 `r get_intrinsic_importance_plot_description(opts, grp = FALSE)`
 
 ```{r ic50indivimp, eval = ("ic50" %in% opts$outcomes) & (("marg" %in% opts$importance_ind) | ("cond" %in% opts$importance_ind)), fig.cap = intrinsic_importance_figure_caption(ncomplete_ic50, num_obs_fulls, num_obs_reds, "ic50", grp = FALSE, marg = "marg" %in% opts$importance_ind, cond = "cond" %in% opts$importance_ind, opts = opts, vimp_threshold = vimp_threshold, any_signif = switch(use_cv + 1, log10.pc.ic50_any_signif, log10.pc.ic50_any_signif_cv)), fig.subcap = c("Marginal importance", "Conditional importance")}
@@ -460,7 +460,7 @@ if ("figures" %in% opts$return) {
 
 `r if (!("ic80" %in% opts$outcomes) | (!("marg" %in% opts$importance_ind) & !("cond" %in% opts$importance_ind))) "<!--"`
 
-We show the intrinsic variable importance of individual features in predicting `r ifelse(length(opts$nab) == 1, "", "estimated")` IC$_{80}$ in Figure \@ref(fig:ic80indivimp). Importance is defined using the difference in $R^2$ values.
+We show the intrinsic variable importance of individual `r ind_import_txt` in predicting `r ifelse(length(opts$nab) == 1, "", "estimated")` IC$_{80}$ in Figure \@ref(fig:ic80indivimp). Importance is defined using the difference in $R^2$ values.
 `r get_intrinsic_importance_plot_description(opts, grp = FALSE)`
 
 ```{r ic80indivimp, eval = ("ic80" %in% opts$outcomes) & (("marg" %in% opts$importance_ind) | ("cond" %in% opts$importance_ind)), fig.cap = intrinsic_importance_figure_caption(ncomplete_ic80, num_obs_fulls, num_obs_reds, "ic80", grp = FALSE, marg = "marg" %in% opts$importance_ind, cond = "cond" %in% opts$importance_ind, opts = opts, vimp_threshold = vimp_threshold, any_signif = switch(use_cv + 1, log10.pc.ic80_any_signif, log10.pc.ic80_any_signif_cv)), fig.subcap = c("Marginal importance", "Conditional importance")}
@@ -623,7 +623,7 @@ if ("figures" %in% opts$return) {
 
 `r if (!("iip" %in% opts$outcomes) | (!("marg" %in% opts$importance_ind) & !("cond" %in% opts$importance_ind))) "<!--"`
 
-We show the intrinsic variable importance of individual features in predicting IIP in Figure \@ref(fig:iipindivimp). Importance is defined using the difference in $R^2$ values.
+We show the intrinsic variable importance of individual `r ind_import_txt` in predicting IIP in Figure \@ref(fig:iipindivimp). Importance is defined using the difference in $R^2$ values.
 `r get_intrinsic_importance_plot_description(opts, grp = FALSE)`
 
 ```{r iipindivimp, eval = ("iip" %in% opts$outcomes) & (("marg" %in% opts$importance_ind) | ("cond" %in% opts$importance_ind)), fig.cap = intrinsic_importance_figure_caption(ncomplete_ic5080, num_obs_fulls, num_obs_reds, "iip", grp = FALSE, marg = "marg" %in% opts$importance_ind, cond = "cond" %in% opts$importance_ind, opts = opts, vimp_threshold = vimp_threshold, any_signif = switch(use_cv + 1, iip_any_signif, iip_any_signif_cv)), fig.subcap = c("Marginal importance", "Conditional importance")}
@@ -796,7 +796,7 @@ if ("figures" %in% opts$return) {
 
 `r if (!("sens1" %in% opts$outcomes) | (!("marg" %in% opts$importance_ind) & !("cond" %in% opts$importance_ind)) | !ran_vimp_dichot1) "<!--"`
 
-We show the intrinsic variable importance of individual features in predicting `r est_fillin` sensitivity in Figure \@ref(fig:sens1indivimp). Importance is defined using the difference in AUCs.
+We show the intrinsic variable importance of individual `r ind_import_txt` in predicting `r est_fillin` sensitivity in Figure \@ref(fig:sens1indivimp). Importance is defined using the difference in AUCs.
 `r get_intrinsic_importance_plot_description(opts, grp = FALSE)`
 
 ```{r sens1indivimp, eval = ("sens1" %in% opts$outcomes) & (("marg" %in% opts$importance_ind) | ("cond" %in% opts$importance_ind)) & ran_vimp_dichot1, fig.cap = intrinsic_importance_figure_caption(ncomplete_sens, num_obs_fulls, num_obs_reds, "sens1", grp = FALSE, marg = "marg" %in% opts$importance_ind, cond = "cond" %in% opts$importance_ind, opts = opts, vimp_threshold = vimp_threshold, any_signif = switch(use_cv + 1, dichotomous.1_any_signif, dichotomous.1_any_signif_cv)), fig.subcap = c("Marginal importance", "Conditional importance")}
@@ -971,7 +971,7 @@ if ("figures" %in% opts$return) {
 
 `r if (!("sens2" %in% opts$outcomes) | (!("marg" %in% opts$importance_ind) & !("cond" %in% opts$importance_ind)) | !ran_vimp_dichot2) "<!--"`
 
-We show the intrinsic variable importance of individual features in predicting multiple sensitivity in Figure \@ref(fig:sens2indivimp). Importance is defined using the difference in AUCs.
+We show the intrinsic variable importance of individual `r ind_import_txt` in predicting multiple sensitivity in Figure \@ref(fig:sens2indivimp). Importance is defined using the difference in AUCs.
 `r get_intrinsic_importance_plot_description(opts, grp = FALSE)`
 
 ```{r sens2indivimp, eval = ("sens2" %in% opts$outcomes) & (("marg" %in% opts$importance_ind) | ("cond" %in% opts$importance_ind)) & ran_vimp_dichot2, fig.cap = intrinsic_importance_figure_caption(ncomplete_sens, num_obs_fulls, num_obs_reds, "sens2", grp = FALSE, marg = "marg" %in% opts$importance_ind, cond = "cond" %in% opts$importance_ind, opts = opts, vimp_threshold = vimp_threshold, any_signif = switch(use_cv + 1, dichotomous.2_any_signif, dichotomous.2_any_signif_cv)), fig.subcap = c("Marginal importance", "Conditional importance")}

--- a/code/05_report.Rmd
+++ b/code/05_report.Rmd
@@ -238,7 +238,7 @@ if ("figures" %in% opts$return) {
 
 `r if (!("ic50" %in% opts$outcomes) | ((opts$importance_grp == "") & !(("marg" %in% opts$importance_ind) | ("cond" %in% opts$importance_ind)))) "<!--"`
 
-### Biological importance
+### Intrinsic importance
 
 `r if (!("ic50" %in% opts$outcomes) | ((opts$importance_grp == "") & !(("marg" %in% opts$importance_ind) | ("cond" %in% opts$importance_ind)))) "-->"`
 
@@ -255,9 +255,9 @@ if (("marg" %in% opts$importance_grp) & ("cond" %in% opts$importance_grp)) {
 } else {
   ic50_grp_vimp_grob_lst <- switch(use_cv + 1,log10.pc.ic50_vimp_plots$grp_conditional, log10.pc.ic50_cv_vimp_plots$grp_conditional)
 }
-grid.arrange(grobs = list(ic50_grp_vimp_grob_lst), ncol = length(opts$importance_grp), top = "Group Biological Variable Importance")
+grid.arrange(grobs = list(ic50_grp_vimp_grob_lst), ncol = length(opts$importance_grp), top = "Group Intrinsic Variable Importance")
 if ("figures" %in% opts$return) {
-    ggsave(filename = paste0("/home/output/ic50_biol_import_grp_", postfix, ".png"), plot = grid.arrange(grobs = list(ic50_grp_vimp_grob_lst), ncol = length(opts$importance_grp), top = "Group Biological Variable Importance"), width = 20, height = 20, units = "cm")
+    ggsave(filename = paste0("/home/output/ic50_biol_import_grp_", postfix, ".png"), plot = grid.arrange(grobs = list(ic50_grp_vimp_grob_lst), ncol = length(opts$importance_grp), top = "Group Intrinsic Variable Importance"), width = 20, height = 20, units = "cm")
 }
 ```
 
@@ -277,9 +277,9 @@ if (("marg" %in% opts$importance_ind) & ("cond" %in% opts$importance_ind)) {
 } else {
   ic50_ind_vimp_grob_lst <- switch(use_cv + 1,log10.pc.ic50_vimp_plots$ind_conditional, log10.pc.ic50_cv_vimp_plots$ind_conditional)
 }
-grid.arrange(grobs = list(ic50_ind_vimp_grob_lst), ncol = ifelse("pred" %in% opts$importance_ind, length(opts$importance_ind) - 1, length(opts$importance_ind)), top = "Individual Biological Variable Importance")
+grid.arrange(grobs = list(ic50_ind_vimp_grob_lst), ncol = ifelse("pred" %in% opts$importance_ind, length(opts$importance_ind) - 1, length(opts$importance_ind)), top = "Individual Intrinsic Variable Importance")
 if ("figures" %in% opts$return) {
-    ggsave(filename = paste0("/home/output/ic50_biol_import_ind_", postfix, ".png"), plot = grid.arrange(grobs = list(ic50_ind_vimp_grob_lst), ncol = ifelse("pred" %in% opts$importance_ind, length(opts$importance_ind) - 1, length(opts$importance_ind)), top = "Individual Biological Variable Importance"), width = 20, height = 20, units = "cm")
+    ggsave(filename = paste0("/home/output/ic50_biol_import_ind_", postfix, ".png"), plot = grid.arrange(grobs = list(ic50_ind_vimp_grob_lst), ncol = ifelse("pred" %in% opts$importance_ind, length(opts$importance_ind) - 1, length(opts$importance_ind)), top = "Individual Intrinsic Variable Importance"), width = 20, height = 20, units = "cm")
 }
 ```
 
@@ -428,7 +428,7 @@ if ("figures" %in% opts$return) {
 
 `r if (!("ic80" %in% opts$outcomes) | ((opts$importance_grp == "") & !(("marg" %in% opts$importance_ind) | ("cond" %in% opts$importance_ind)))) "<!--"`
 
-### Biological importance
+### Intrinsic importance
 
 `r if (!("ic80" %in% opts$outcomes) | ((opts$importance_grp == "") & !(("marg" %in% opts$importance_ind) | ("cond" %in% opts$importance_ind)))) "-->"`
 
@@ -448,9 +448,9 @@ if (("marg" %in% opts$importance_grp) & ("cond" %in% opts$importance_grp)) {
 } else {
   ic80_grp_vimp_grob_lst <- switch(use_cv + 1,log10.pc.ic80_vimp_plots$grp_conditional, log10.pc.ic80_cv_vimp_plots$grp_conditional)
 }
-grid.arrange(grobs = list(ic80_grp_vimp_grob_lst), ncol = length(opts$importance_grp), top = "Group Biological Variable Importance")
+grid.arrange(grobs = list(ic80_grp_vimp_grob_lst), ncol = length(opts$importance_grp), top = "Group Intrinsic Variable Importance")
 if ("figures" %in% opts$return) {
-    ggsave(filename = paste0("/home/output/ic80_biol_import_grp_", postfix, ".png"), plot = grid.arrange(grobs = list(ic80_grp_vimp_grob_lst), ncol = length(opts$importance_grp), top = "Group Biological Variable Importance"), width = 20, height = 20, units = "cm")
+    ggsave(filename = paste0("/home/output/ic80_biol_import_grp_", postfix, ".png"), plot = grid.arrange(grobs = list(ic80_grp_vimp_grob_lst), ncol = length(opts$importance_grp), top = "Group Intrinsic Variable Importance"), width = 20, height = 20, units = "cm")
 }
 ```
 
@@ -471,9 +471,9 @@ if (("marg" %in% opts$importance_ind) & ("cond" %in% opts$importance_ind)) {
 } else {
   ic80_ind_vimp_grob_lst <- switch(use_cv + 1,log10.pc.ic80_vimp_plots$ind_conditional, log10.pc.ic80_cv_vimp_plots$ind_conditional)
 }
-grid.arrange(grobs = list(ic80_ind_vimp_grob_lst), ncol = ifelse("pred" %in% opts$importance_ind, length(opts$importance_ind) - 1, length(opts$importance_ind)), top = "Individual Biological Variable Importance")
+grid.arrange(grobs = list(ic80_ind_vimp_grob_lst), ncol = ifelse("pred" %in% opts$importance_ind, length(opts$importance_ind) - 1, length(opts$importance_ind)), top = "Individual Intrinsic Variable Importance")
 if ("figures" %in% opts$return) {
-    ggsave(filename = paste0("/home/output/ic80_biol_import_ind_", postfix, ".png"), plot = grid.arrange(grobs = list(ic80_ind_vimp_grob_lst), ncol = ifelse("pred" %in% opts$importance_ind, length(opts$importance_ind) - 1, length(opts$importance_ind)), top = "Individual Biological Variable Importance"), width = 20, height = 20, units = "cm")
+    ggsave(filename = paste0("/home/output/ic80_biol_import_ind_", postfix, ".png"), plot = grid.arrange(grobs = list(ic80_ind_vimp_grob_lst), ncol = ifelse("pred" %in% opts$importance_ind, length(opts$importance_ind) - 1, length(opts$importance_ind)), top = "Individual Intrinsic Variable Importance"), width = 20, height = 20, units = "cm")
 }
 ```
 
@@ -591,7 +591,7 @@ if ("figures" %in% opts$return) {
 
 `r if (!("iip" %in% opts$outcomes) | ((opts$importance_grp == "") & !(("marg" %in% opts$importance_ind) | ("cond" %in% opts$importance_ind)))) "<!--"`
 
-### Biological importance
+### Intrinsic importance
 
 `r if (!("iip" %in% opts$outcomes) | ((opts$importance_grp == "") & !(("marg" %in% opts$importance_ind) | ("cond" %in% opts$importance_ind)))) "-->"`
 
@@ -611,9 +611,9 @@ if (("marg" %in% opts$importance_grp) & ("cond" %in% opts$importance_grp)) {
 } else {
   iip_grp_vimp_grob_lst <- switch(use_cv + 1,iip_vimp_plots$grp_conditional, iip_cv_vimp_plots$grp_conditional)
 }
-grid.arrange(grobs = list(iip_grp_vimp_grob_lst), ncol = length(opts$importance_grp), top = "Group Biological Variable Importance")
+grid.arrange(grobs = list(iip_grp_vimp_grob_lst), ncol = length(opts$importance_grp), top = "Group Intrinsic Variable Importance")
 if ("figures" %in% opts$return) {
-    ggsave(filename = paste0("/home/output/iip_biol_import_grp_", postfix, ".png"), plot = grid.arrange(grobs = list(iip_grp_vimp_grob_lst), ncol = length(opts$importance_grp), top = "Group Biological Variable Importance"), width = 20, height = 20, units = "cm")
+    ggsave(filename = paste0("/home/output/iip_biol_import_grp_", postfix, ".png"), plot = grid.arrange(grobs = list(iip_grp_vimp_grob_lst), ncol = length(opts$importance_grp), top = "Group Intrinsic Variable Importance"), width = 20, height = 20, units = "cm")
 }
 ```
 
@@ -634,9 +634,9 @@ if (("marg" %in% opts$importance_ind) & ("cond" %in% opts$importance_ind)) {
 } else {
   iip_ind_vimp_grob_lst <- switch(use_cv + 1,iip_vimp_plots$ind_conditional, iip_cv_vimp_plots$ind_conditional)
 }
-grid.arrange(grobs = list(iip_ind_vimp_grob_lst), ncol = ifelse("pred" %in% opts$importance_ind, length(opts$importance_ind) - 1, length(opts$importance_ind)), top = "Individual Biological Variable Importance")
+grid.arrange(grobs = list(iip_ind_vimp_grob_lst), ncol = ifelse("pred" %in% opts$importance_ind, length(opts$importance_ind) - 1, length(opts$importance_ind)), top = "Individual Intrinsic Variable Importance")
 if ("figures" %in% opts$return) {
-    ggsave(filename = paste0("/home/output/iip_biol_import_ind_", postfix, ".png"), plot = grid.arrange(grobs = list(iip_ind_vimp_grob_lst), ncol = ifelse("pred" %in% opts$importance_ind, length(opts$importance_ind) - 1, length(opts$importance_ind)), top = "Individual Biological Variable Importance"), width = 20, height = 20, units = "cm")
+    ggsave(filename = paste0("/home/output/iip_biol_import_ind_", postfix, ".png"), plot = grid.arrange(grobs = list(iip_ind_vimp_grob_lst), ncol = ifelse("pred" %in% opts$importance_ind, length(opts$importance_ind) - 1, length(opts$importance_ind)), top = "Individual Intrinsic Variable Importance"), width = 20, height = 20, units = "cm")
 }
 ```
 
@@ -764,7 +764,7 @@ if ("figures" %in% opts$return) {
 
 `r if (!("sens1" %in% opts$outcomes) | ((opts$importance_grp == "") & !(("marg" %in% opts$importance_ind) | ("cond" %in% opts$importance_ind))) | !ran_vimp_dichot1) "<!--"`
 
-### Biological importance
+### Intrinsic importance
 
 `r if (!("sens1" %in% opts$outcomes) | ((opts$importance_grp == "") & !(("marg" %in% opts$importance_ind) | ("cond" %in% opts$importance_ind))) | !ran_vimp_dichot1) "-->"`
 
@@ -784,9 +784,9 @@ if (("marg" %in% opts$importance_grp) & ("cond" %in% opts$importance_grp)) {
 } else {
   sens1_grp_vimp_grob_lst <- switch(use_cv + 1,dichotomous.1_vimp_plots$grp_conditional, dichotomous.1_cv_vimp_plots$grp_conditional)
 }
-grid.arrange(grobs = list(sens1_grp_vimp_grob_lst), ncol = length(opts$importance_grp), top = "Group Biological Variable Importance")
+grid.arrange(grobs = list(sens1_grp_vimp_grob_lst), ncol = length(opts$importance_grp), top = "Group Intrinsic Variable Importance")
 if ("figures" %in% opts$return) {
-    ggsave(filename = paste0("/home/output/", sens1_plot_nm, "_biol_import_grp_", postfix, ".png"), plot = grid.arrange(grobs = list(sens1_grp_vimp_grob_lst), ncol = length(opts$importance_grp), top = "Group Biological Variable Importance"), width = 20, height = 20, units = "cm")
+    ggsave(filename = paste0("/home/output/", sens1_plot_nm, "_biol_import_grp_", postfix, ".png"), plot = grid.arrange(grobs = list(sens1_grp_vimp_grob_lst), ncol = length(opts$importance_grp), top = "Group Intrinsic Variable Importance"), width = 20, height = 20, units = "cm")
 }
 ```
 
@@ -807,9 +807,9 @@ if (("marg" %in% opts$importance_ind) & ("cond" %in% opts$importance_ind)) {
 } else {
   sens1_ind_vimp_grob_lst <- switch(use_cv + 1,dichotomous.1_vimp_plots$ind_conditional, dichotomous.1_cv_vimp_plots$ind_conditional)
 }
-grid.arrange(grobs = list(sens1_ind_vimp_grob_lst), ncol = ifelse("pred" %in% opts$importance_ind, length(opts$importance_ind) - 1, length(opts$importance_ind)), top = "Individual Biological Variable Importance")
+grid.arrange(grobs = list(sens1_ind_vimp_grob_lst), ncol = ifelse("pred" %in% opts$importance_ind, length(opts$importance_ind) - 1, length(opts$importance_ind)), top = "Individual Intrinsic Variable Importance")
 if ("figures" %in% opts$return) {
-    ggsave(filename = paste0("/home/output/", sens1_plot_nm, "_biol_import_ind_", postfix, ".png"), plot = grid.arrange(grobs = list(sens1_ind_vimp_grob_lst), ncol = ifelse("pred" %in% opts$importance_ind, length(opts$importance_ind) - 1, length(opts$importance_ind)), top = "Individual Biological Variable Importance"), width = 20, height = 20, units = "cm")
+    ggsave(filename = paste0("/home/output/", sens1_plot_nm, "_biol_import_ind_", postfix, ".png"), plot = grid.arrange(grobs = list(sens1_ind_vimp_grob_lst), ncol = ifelse("pred" %in% opts$importance_ind, length(opts$importance_ind) - 1, length(opts$importance_ind)), top = "Individual Intrinsic Variable Importance"), width = 20, height = 20, units = "cm")
 }
 ```
 
@@ -939,7 +939,7 @@ if ("figures" %in% opts$return) {
 
 `r if (!("sens2" %in% opts$outcomes) | ((opts$importance_grp == "") & !(("marg" %in% opts$importance_ind) | ("cond" %in% opts$importance_ind))) | !ran_vimp_dichot2) "<!--"`
 
-### Biological importance
+### Intrinsic importance
 
 `r if (!("sens2" %in% opts$outcomes) | ((opts$importance_grp == "") & !(("marg" %in% opts$importance_ind) | ("cond" %in% opts$importance_ind))) | !ran_vimp_dichot2) "-->"`
 
@@ -959,9 +959,9 @@ if (("marg" %in% opts$importance_grp) & ("cond" %in% opts$importance_grp)) {
 } else {
   sens2_grp_vimp_grob_lst <- switch(use_cv + 1,dichotomous.2_vimp_plots$grp_conditional, dichotomous.2_cv_vimp_plots$grp_conditional)
 }
-grid.arrange(grobs = list(sens2_grp_vimp_grob_lst), ncol = length(opts$importance_grp), top = "Group Biological Variable Importance")
+grid.arrange(grobs = list(sens2_grp_vimp_grob_lst), ncol = length(opts$importance_grp), top = "Group Intrinsic Variable Importance")
 if ("figures" %in% opts$return) {
-    ggsave(filename = paste0("/home/output/multsens_biol_import_grp_", postfix, ".png"), plot = grid.arrange(grobs = list(sens2_grp_vimp_grob_lst), ncol = length(opts$importance_grp), top = "Group Biological Variable Importance"), width = 20, height = 20, units = "cm")
+    ggsave(filename = paste0("/home/output/multsens_biol_import_grp_", postfix, ".png"), plot = grid.arrange(grobs = list(sens2_grp_vimp_grob_lst), ncol = length(opts$importance_grp), top = "Group Intrinsic Variable Importance"), width = 20, height = 20, units = "cm")
 }
 ```
 
@@ -982,9 +982,9 @@ if (("marg" %in% opts$importance_ind) & ("cond" %in% opts$importance_ind)) {
 } else {
   sens2_ind_vimp_grob_lst <- switch(use_cv + 1,dichotomous.2_vimp_plots$ind_conditional, dichotomous.2_cv_vimp_plots$ind_conditional)
 }
-grid.arrange(grobs = list(sens2_ind_vimp_grob_lst), ncol = ifelse("pred" %in% opts$importance_ind, length(opts$importance_ind) - 1, length(opts$importance_ind)), top = "Individual Biological Variable Importance")
+grid.arrange(grobs = list(sens2_ind_vimp_grob_lst), ncol = ifelse("pred" %in% opts$importance_ind, length(opts$importance_ind) - 1, length(opts$importance_ind)), top = "Individual Intrinsic Variable Importance")
 if ("figures" %in% opts$return) {
-    ggsave(filename = paste0("/home/output/multsens_biol_import_ind_", postfix, ".png"), plot = grid.arrange(grobs = list(sens2_ind_vimp_grob_lst), ncol = ifelse("pred" %in% opts$importance_ind, length(opts$importance_ind) - 1, length(opts$importance_ind)), top = "Individual Biological Variable Importance"), width = 20, height = 20, units = "cm")
+    ggsave(filename = paste0("/home/output/multsens_biol_import_ind_", postfix, ".png"), plot = grid.arrange(grobs = list(sens2_ind_vimp_grob_lst), ncol = ifelse("pred" %in% opts$importance_ind, length(opts$importance_ind) - 1, length(opts$importance_ind)), top = "Individual Intrinsic Variable Importance"), width = 20, height = 20, units = "cm")
 }
 ```
 

--- a/code/05_report_preamble.R
+++ b/code/05_report_preamble.R
@@ -269,4 +269,4 @@ sens1_plot_nm <- ifelse(length(opts$nab) == 1, "sens", "estsens")
 sens2_min_num <- min(c(length(opts$nab), opts$multsens_nab))
 
 # print "features" for individual intrinsic importance if type is residuewise, otherwise print "sites"
-ind_import_txt <- switch((grepl("residue", opts$ind_import_type)) + 1, "sites, subtype variables, and viral geometry variables", "features")
+ind_import_txt <- switch((grepl("residue", opts$ind_importance_type)) + 1, "sites, subtype variables, and viral geometry variables", "features")

--- a/code/05_report_preamble.R
+++ b/code/05_report_preamble.R
@@ -124,8 +124,9 @@ all_outcome_names <- c("log10.pc.ic50", "log10.pc.ic80", "iip", "dichotomous.1",
 # get variable groups
 all_var_groups <- get_variable_groups(dat, pred_names)
 all_geog_vars <- pred_names[grepl("geog", pred_names)]
+# get individual variables -- either sitewise or residuewise
 num_covs <- length(pred_names) - length(all_geog_vars)
-var_inds <- pred_names[!grepl("geog", pred_names)][1:num_covs]
+var_inds <- get_individual_features(pred_names[!grepl("geog", pred_names)][1:num_covs], opts$ind_importance_type)
 
 # set number of CV folds
 V <- as.numeric(opts$nfolds)
@@ -266,3 +267,6 @@ ran_sl_dichot2 <- ifelse(length(ran_sl_dichot2) == 0, FALSE, ran_sl_dichot2)
 # nice plot name for sens1
 sens1_plot_nm <- ifelse(length(opts$nab) == 1, "sens", "estsens")
 sens2_min_num <- min(c(length(opts$nab), opts$multsens_nab))
+
+# print "features" for individual intrinsic importance if type is residuewise, otherwise print "sites"
+ind_import_txt <- switch((grepl("residue", opts$ind_import_type)) + 1, "sites, subtype variables, and viral geometry variables", "features")

--- a/docs/slapnap_documentation.Rmd
+++ b/docs/slapnap_documentation.Rmd
@@ -247,17 +247,17 @@ When `cvperf="TRUE"` and a super learner is constructed, an additional layer of 
 
 ## Variable importance
 
-If `importance_grp` or `importance_ind` is specified, variable importance estimates are computed based on the `learners`. Both biological and prediction importance can be obtained; we discuss each in the following two sections.
+If `importance_grp` or `importance_ind` is specified, variable importance estimates are computed based on the `learners`. Both intrinsic and prediction importance can be obtained; we discuss each in the following two sections.
 
 ### Biological importance {#sec:biolimp}
 
-Biological importance may be obtained by specifying `importance_grp`, `importance_ind`, or both. We provide two types of biological importance: marginal and conditional, accessed by passing `"marg"` and `"cond"`, respectively, to one of the importance variables. Both types of biological importance are based on the population prediction potential of features [@williamson2020], as implemented in the `R` package `vimp` [@vimppkg]. We measure prediction potential using nonparametric $R^2$ for continuous outcomes (i.e., IC$_{50}$, IC$_{80}$, or IIP) and using the nonparametric area under the receiver operating characteristic curve (AUC) for binary outcomes (i.e., sensitivity, estimated sensitivity, or multiple sensitivity). In both marginal and conditional importance, we compare the population prediction potential including the feature(s) of interest to the population prediction potential excluding the feature(s) or interest; this provides a measure of the biological importance of the feature(s). The two types of biological importance differ only in the other adjustment variables that we consider: conditional importance compares the prediction potential of all features to the prediction potential of all features excluding the feature(s) of interest, and thus importance must be interpreted conditionally; whereas marginal importance compares the prediction potential of the feature(s) of interest plus geographic confounders to the prediction potential of the geographic confounders alone.
+Biological importance may be obtained by specifying `importance_grp`, `importance_ind`, or both. We provide two types of intrinsic importance: marginal and conditional, accessed by passing `"marg"` and `"cond"`, respectively, to one of the importance variables. Both types of intrinsic importance are based on the population prediction potential of features [@williamson2020], as implemented in the `R` package `vimp` [@vimppkg]. We measure prediction potential using nonparametric $R^2$ for continuous outcomes (i.e., IC$_{50}$, IC$_{80}$, or IIP) and using the nonparametric area under the receiver operating characteristic curve (AUC) for binary outcomes (i.e., sensitivity, estimated sensitivity, or multiple sensitivity). In both marginal and conditional importance, we compare the population prediction potential including the feature(s) of interest to the population prediction potential excluding the feature(s) or interest; this provides a measure of the intrinsic importance of the feature(s). The two types of intrinsic importance differ only in the other adjustment variables that we consider: conditional importance compares the prediction potential of all features to the prediction potential of all features excluding the feature(s) of interest, and thus importance must be interpreted conditionally; whereas marginal importance compares the prediction potential of the feature(s) of interest plus geographic confounders to the prediction potential of the geographic confounders alone.
 
-Both marginal and conditional biological importance can be computed for groups of features or individual features. The available feature groups are detailed in Section \@ref(sec:data). Execution time may increase when biological importance is requested, depending upon the other options passed to `slapnap`: a separate `learner` (or super learner ensemble) must be trained for each feature group (or individual feature) of interest. Marginal importance tends to be computed more quickly than conditional importance, but both types of importance provide useful information about the population of interest and the underlying biology.
+Both marginal and conditional intrinsic importance can be computed for groups of features or individual features. The available feature groups are detailed in Section \@ref(sec:data). Execution time may increase when intrinsic importance is requested, depending upon the other options passed to `slapnap`: a separate `learner` (or super learner ensemble) must be trained for each feature group (or individual feature) of interest. Marginal importance tends to be computed more quickly than conditional importance, but both types of importance provide useful information about the population of interest and the underlying biology.
 
-If biological importance is requested, then point estimates, confidence intervals, and p-values (for a test of the null hypothesis that the biological importance is equal to zero) will be computed and displayed for each feature or group of features of interest. All results are based on first creating two independent splits of the data: the population prediction potential including the feature(s) of interest is estimated on one half of the data, while the population prediction potential excluding the feature(s) of interest is estimated on the remaining half. This ensures that the procedure has the desired type I error rate.
+If intrinsic importance is requested, then point estimates, confidence intervals, and p-values (for a test of the null hypothesis that the intrinsic importance is equal to zero) will be computed and displayed for each feature or group of features of interest. All results are based on first creating two independent splits of the data: the population prediction potential including the feature(s) of interest is estimated on one half of the data, while the population prediction potential excluding the feature(s) of interest is estimated on the remaining half. This ensures that the procedure has the desired type I error rate.
 
-In the following command, we request marginal biological importance for the feature groups defined in Section \@ref(sec:data). We do not specify a super learner ensemble to reduce computation time; however, in most problems we recommend an ensemble to protect against model misspecification.
+In the following command, we request marginal intrinsic importance for the feature groups defined in Section \@ref(sec:data). We do not specify a super learner ensemble to reduce computation time; however, in most problems we recommend an ensemble to protect against model misspecification.
 
 ```{bash, eval = FALSE}
 docker run -v /path/to/local/dir:/home/output \
@@ -265,7 +265,7 @@ docker run -v /path/to/local/dir:/home/output \
            slapnap/slapnap
 ```
 
-The raw `R` objects (saved as `.rds` files) containing the point estimates, confidence intervals, and p-values for biological importance can be saved by passing `"vimp"` to `return`.
+The raw `R` objects (saved as `.rds` files) containing the point estimates, confidence intervals, and p-values for intrinsic importance can be saved by passing `"vimp"` to `return`.
 
 ### Predictive importance
 
@@ -301,16 +301,16 @@ The executive summary contains:
 * descriptive statistics detailing the number of sequences extracted from CATNAP, the number of sequences with complete feature and outcome information, and the number of estimated sensitive and resistant sequences (defined based on sensitivity, estimated sensitivity, and/or multiple sensitivity);
 * a table describing the `learners` used to predict each outcome;
 * a table of cross-validated prediction performance for each outcome (if `cvperf = TRUE`);
-* a table of ranked marginal biological prediction performance for each feature group and outcome (if `"marg"` is included in `importance_grp`); and
-* a table of ranked conditional biological prediction performance for each feature group and outcome (if `"cond"` is included in `importance_grp`).
+* a table of ranked marginal intrinsic prediction performance for each feature group and outcome (if `"marg"` is included in `importance_grp`); and
+* a table of ranked conditional intrinsic prediction performance for each feature group and outcome (if `"cond"` is included in `importance_grp`).
 
 The rest of the report is organized by outcome. Each of these sections contains descriptive statistics including summaries of the distribution of the outcome (raw and log-transformed) for each bnAb for continuous outcomes and number sensitive/resistant for binary outcomes. Based on the specific options passed to `slapnap`, the following subsections may also be present:
 
 * a table of super learner weights (Section \@ref(sec:sldetails)) if an ensemble is used;
 * cross-validated prediction performance for the fitted learner (or super learner): figures showing cross-validated prediction performance (all outcomes), cross-validated receiver operating characteristic (ROC) curves (binary outcomes), and cross-validated predicted probabilities of resistance (binary outcomes); and
-* variable importance: biological importance (group and individual) and predictive importance.
+* variable importance: intrinsic importance (group and individual) and predictive importance.
 
-Finally, if group biological importance is requested, then the variable groups are displayed in a section immediately preceding the references.
+Finally, if group intrinsic importance is requested, then the variable groups are displayed in a section immediately preceding the references.
 
 ## Example reports
 
@@ -318,7 +318,7 @@ Here we include several example reports and the `slapnap` container `run` comman
 
 ### Single antibodies
 
-The following code evaluates binary sensitivity (defined as the indicator that IC$_{80} < 1$) for VRC01 using a super learner that includes all three learner types, each with multiple tuning arameter values, and with different variable screening techniques. We also request marginal group and individual biological importance and individual predictive importance. If running this command locally, change `docker_output_directory` to the path to the folder where the output is to be saved.
+The following code evaluates binary sensitivity (defined as the indicator that IC$_{80} < 1$) for VRC01 using a super learner that includes all three learner types, each with multiple tuning arameter values, and with different variable screening techniques. We also request marginal group and individual intrinsic importance and individual predictive importance. If running this command locally, change `docker_output_directory` to the path to the folder where the output is to be saved.
 
 [See the report](reports/report_VRC01.html)
 


### PR DESCRIPTION
In the first version of SLAPNAP, we measured individual importance the same way that we measured predictive importance -- namely, on the level of presence/absence of a particular residue at a given site (e.g., D at 757). This update allows intrinsic importance to be measured at the site level instead (e.g., importance of site 757), using a new flag, `ind_importance_type`, which can take values `"sitewise"` or `"residuewise"`.