### PR TITLE
Add H2O to report and book

### DIFF
--- a/code/00_utils.R
+++ b/code/00_utils.R
@@ -298,7 +298,7 @@ get_learner_descriptions <- function(opts, n_total_ft = NA, n_ft_screen = NA){
         }else if(opts$learners[1] == "lasso"){
             "elastic net regression [@zou2005]"
         } else if (opts$learners[1] == "h2oboost") {
-            "H2O.ai boosting [@h2opkg]"
+            "gradient boosted trees [@h2opkg]"
         }
         if(all(opts$var_thresh == 0) & !opts$cvtune){
             tmp <- paste0(tmp, " with tuning parameters set to their 'default' values.")

--- a/code/00_utils.R
+++ b/code/00_utils.R
@@ -297,12 +297,14 @@ get_learner_descriptions <- function(opts, n_total_ft = NA, n_ft_screen = NA){
             "extreme gradient boosting [@chen2016]"
         }else if(opts$learners[1] == "lasso"){
             "elastic net regression [@zou2005]"
+        } else if (opts$learners[1] == "h2oboost") {
+            "H2O.ai boosting [@h2opkg]"
         }
         if(all(opts$var_thresh == 0) & !opts$cvtune){
             tmp <- paste0(tmp, " with tuning parameters set to their 'default' values.")
         }else if(all(opts$var_thresh == 0) & opts$cvtune){
             tmp <- paste0(tmp, " with tuning parameters selected using a limited grid search and cross-validation.")
-        }else if(!all(opts$var_thresh == 0) & !opts$cvtune & opts$learner != "xgboost"){
+        }else if(!all(opts$var_thresh == 0) & !opts$cvtune & !grepl("boost", opts$learners)){
             if(length(opts$var_thresh) == 1){
                 tmp <- paste0(tmp, " with tuning parameters set to their 'default' values.",
                               " Variable pre-screening was applied to ensure all binary features had at least ", opts$var_thresh, " minority variants.",
@@ -313,7 +315,7 @@ get_learner_descriptions <- function(opts, n_total_ft = NA, n_ft_screen = NA){
                               " This constituted a total of ", paste0(n_ft_screen, "/", n_total_ft, collapse = ", "), " features, respectively.",
                               " The optimal screening approach was selected using cross-validation.")
             }
-        }else if(!all(opts$var_thresh == 0) & opts$cvtune & opts$learner != "xgboost"){
+        }else if(!all(opts$var_thresh == 0) & opts$cvtune & !grepl("boost", opts$learners)){
             if(length(opts$var_thresh) == 1){
                 tmp <- paste0(tmp, " with tuning parameters selected using a limited grid search and cross-validation.",
                               " Variable pre-screening was applied to ensure all binary features had at least ", opts$var_thresh, " minority variants.",
@@ -332,29 +334,30 @@ get_learner_descriptions <- function(opts, n_total_ft = NA, n_ft_screen = NA){
         if("rf" %in% opts$learners){
             lib_label <- c(lib_label, paste0(ifelse(opts$cvtune, "several ", ""), "random forest", ifelse(opts$cvtune, "s [@breiman2001] with varied tuning parameters", " [@breiman2001]")))
         }
+        if ("h2oboost" %in% opts$learners) {
+            lib_label <- c(lib_label, "gradient boosted trees with tuning parameters chosen via cross-validation [@h2opkg]")
+        }
         if("xgboost" %in% opts$learners){
-            if("rf" %in% opts$learners){
-                if(!("lasso" %in% opts$learners)){
-                    lib_label <- paste0(lib_label, " and ")
-                }else{
-                    lib_label <- paste0(lib_label, ", ")
-                }
-            }
-            lib_label <- paste0(lib_label, paste0(ifelse(opts$cvtune, "several ", ""), "gradient boosted tree", ifelse(opts$cvtune, "s [@chen2016] with varied tuning parameters", " [@chen2016]")))
+            lib_label <- c(lib_label, paste0(ifelse(opts$cvtune, "several ", ""), "gradient boosted tree", ifelse(opts$cvtune, "s [@chen2016] with varied tuning parameters", " [@chen2016]")))
         }
         if("lasso" %in% opts$learners){
-            if("rf" %in% opts$learners | "xgboost" %in% opts$learners){
-                lib_label <- paste0(lib_label, " and ")
-            }
-            lib_label <- paste0(lib_label, paste0(ifelse(opts$cvtune, "several ", ""), "elastic net regression", ifelse(opts$cvtune, "s [@zou2005] with varied tuning parameters", " [@zou2005]")))
+            lib_label <- c(lib_label, paste0(ifelse(opts$cvtune, "several ", ""), "elastic net regression", ifelse(opts$cvtune, "s [@zou2005] with varied tuning parameters", " [@zou2005]")))
         }
-        tmp <- paste0("a super learner ensemble [@vanderlaan2007] of ", lib_label, " and intercept-only regression.")
+        if (length(lib_label) > 2) {
+            final_lib_label <- paste0(c(paste0(lib_label[-length(lib_label)], collapse = ", "), lib_label[length(lib_label)]), collapse = ", and ")
+        } else if (length(lib_label) > 1) {
+            final_lib_label <- paste0(lib_label, collapse = " and ")
+        } else {
+            final_lib_label <- lib_label
+        }
+        tmp <- paste0("a super learner ensemble [@vanderlaan2007] of ", final_lib_label, " and intercept-only regression.")
         if(!all(opts$var_thresh == 0)){
+            except_boost <- ifelse(any(grepl("boost", opts$learners)), paste0("(excepting ", paste0(c(switch(("xgboost" %in% opts$learners) + 1, NULL, "xgboost"), switch(("h2oboost" %in% opts$learners) + 1, NULL, "h2oboost")), collapse = " and "), ")"), "")
             if(length(opts$var_thresh) == 1){
-                tmp <- paste0(tmp, " Each algorithm ", ifelse("xgboost" %in% opts$learners, "(excepting xgboost) ", ""), "included a variable pre-screening to ensure all binary features had at least ", opts$var_thresh, " minority variants.",
+                tmp <- paste0(tmp, " Each algorithm ", except_boost, "included a variable pre-screening to ensure all binary features had at least ", opts$var_thresh, " minority variants.",
                               " This constituted a total of ", n_ft_screen, "/", n_total_ft, " features.")
             }else{
-                tmp <- paste0(tmp, " Each algorithm ", ifelse("xgboost" %in% opts$learners, "(excepting xgboost) ", ""), "was additionally implemented in combination with variable pre-screening procedures to ensure that all binary features had at least ", paste0(opts$var_thresh, collapse = ", "), " minority variants.",
+                tmp <- paste0(tmp, " Each algorithm ", except_boost, "was additionally implemented in combination with variable pre-screening procedures to ensure that all binary features had at least ", paste0(opts$var_thresh, collapse = ", "), " minority variants.",
                               " This constituted a total of ", paste0(n_ft_screen, "/", n_total_ft, collapse = ", "), " features, respectively.")
             }
         }
@@ -408,7 +411,8 @@ get_sllibtab_caption <- function(opts = list(learners = "rf", var_thresh = 0)){
                 tmp <- paste0(tmp, ". Variable pre-screening procedures were applied to each algorithm to ensure that all binary features had at least ", paste0(opts$var_thresh, collapse = ", "), " minority variants.",
                               " The optimal screening approach was selected using cross-validation.")
             }else{
-                tmp <- paste0(tmp, ". Each algorithm ", ifelse("xgboost" %in% opts$learners, "(excepting xgboost) ", ""), "was additionally implemented in combination with variable pre-screening procedures to ensure that all binary features had at least ", paste0(opts$var_thresh, collapse = ", "), " minority variants.")
+                except_boost <- ifelse(any(grepl("boost", opts$learners)), paste0("(excepting ", paste0(c(switch(("xgboost" %in% opts$learners) + 1, NULL, "xgboost"), switch(("h2oboost" %in% opts$learners) + 1, NULL, "h2oboost")), collapse = " and "), ")"), "")
+                tmp <- paste0(tmp, ". Each algorithm ", except_boost, "was additionally implemented in combination with variable pre-screening procedures to ensure that all binary features had at least ", paste0(opts$var_thresh, collapse = ", "), " minority variants.")
             }
         }
     }
@@ -425,6 +429,7 @@ relabel_library <- function(library_names = "SL.ranger", opts = list(var_thresh 
       c("SL.xgboost.6", "xgboost_tune2"),
       c("SL.xgboost.8", "xgboost_tune3"),
       c("SL.xgboost.12", "xgboost_tune4"),
+      c("SL.h2oboost", "h2oboost_default"),
       c("SL.glmnet.0", "lasso_default"),
       c("SL.glmnet.25", "lasso_tune1"),
       c("SL.glmnet.50", "lasso_tune2"),
@@ -443,12 +448,12 @@ relabel_library <- function(library_names = "SL.ranger", opts = list(var_thresh 
     if(!all(opts$var_thresh == 0) & !screens_included){
         tmp <- NULL
         library_names_minus_mean <- library_names[!(library_names %in% c("mean", "Discrete SL", "Super Learner"))]
-        library_names_minus_xgboost <- library_names_minus_mean[!grepl("xgboost", library_names_minus_mean)]
+        library_names_minus_boost <- library_names_minus_mean[!grepl("boost", library_names_minus_mean)]
         for(i in opts$var_thresh){
-            tmp <- c(tmp, paste0(library_names_minus_xgboost, "_screen", i))
+            tmp <- c(tmp, paste0(library_names_minus_boost, "_screen", i))
         }
-        if(any(grepl("xgboost", library_names))){
-            tmp <- c(tmp, library_names[grepl("xgboost", library_names)])
+        if(any(grepl("boost", library_names))){
+            tmp <- c(tmp, library_names[grepl("boost", library_names)])
         }
         if(any(library_names == "mean")){
             tmp <- c(tmp, "mean")
@@ -486,6 +491,8 @@ get_importance_text <- function(opts = list(learners = "rf", cvtune = FALSE, cvp
         if(is_tuned){
             text_out <- paste0(text_out, " These measures are shown for the choice of tuning parameters with the best model fit, as chosen by cross-validation.")
         }
+    } else if (!is_sl & "h2oboost" %in% opts$learners) {
+        text_out <- paste0("Specifically, h2oboost gain importance measures were computed and the top ", n_ft, " features are shown. Gain measures the improvement in accuracy brought by a given feature to the tree branches on which it appears. The essential idea is that before adding a split on a given feature to the branch, there may be some observations that were poorly predicted, while after adding an additional split on this feature, and each resultant branch is more accurate. Gain measures this change in accuracy.")
     }else if(!is_sl & "lasso" %in% opts$learners){
         text_out <- paste0("Specifically, lasso variable importance is taken to be the magnitude of the coefficient for the model with $\\lambda$ chosen via cross-validation, and the top ", n_ft, " are shown.")
         if(is_tuned){
@@ -502,6 +509,8 @@ get_importance_text <- function(opts = list(learners = "rf", cvtune = FALSE, cvp
             text_out <- paste0(text_out, " Overall, there were ", sum(abs(imp_df$Importance) > 0), " features that had non-zero coefficient in the final lasso fit.")
         }else if(algo_with_highest_wt == "xgboost"){
             text_out <- paste0(text_out, "xgboost gain importance measures were computed and are shown by their rank. Gain measures the improvement in accuracy brought by a given feature to the tree branches on which it appears. The essential idea is that before adding a split on a given feature to the branch, there may be some observations that are poorly predicted, while after adding an additional split on this feature, and each resultant branch is more accurate. Gain measures this change in accuracy.")
+        } else if (algo_with_highest_wt == "h2oboost") {
+            text_out <- paste0(text_out, "h2oboost gain importance measures were computed and are shown by their rank. Gain measures the improvement in accuracy brought by a given feature to the tree branches on which it appears. The essential idea is that before adding a split on a given feature to the branch, there may be some observations that are poorly predicted, while after adding an additional split on this feature, and each resultant branch is more accurate. Gain measures this change in accuracy.")
         }
     }
     return(text_out)

--- a/code/03_super_learner_libraries.R
+++ b/code/03_super_learner_libraries.R
@@ -119,7 +119,7 @@ predict.SL.h2oboost <- function(object, newdata, ...)
     }
     pred
 }
-descr_SL.h2oboost <- "boosted regression trees with maximum depth in (2, 4, 5, 6), learning rate in (.05, .1, .2), and column sampling rate in (.1, .2, .3) selected by 5-fold CV"
+descr_SL.h2oboost <- "boosted regression trees with (maximum depth, learning rate, column sampling rate) selected by 5-fold CV over the grid $(2, 4, 5, 6)\\times(.05, .1, .2)\\times(.1, .2, .3)$"
 
 SL.xgboost.corrected <- function (Y, X, newX, family, obsWeights = rep(1, length(Y)), id, ntrees = 1000,
     max_depth = 4, shrinkage = 0.1, minobspernode = 10, params = list(),

--- a/code/03_super_learner_libraries.R
+++ b/code/03_super_learner_libraries.R
@@ -119,6 +119,7 @@ predict.SL.h2oboost <- function(object, newdata, ...)
     }
     pred
 }
+descr_SL.h2oboost <- "boosted regression trees with maximum depth in (2, 4, 5, 6), learning rate in (.05, .1, .2), and column sampling rate in (.1, .2, .3) selected by 5-fold CV"
 
 SL.xgboost.corrected <- function (Y, X, newX, family, obsWeights = rep(1, length(Y)), id, ntrees = 1000,
     max_depth = 4, shrinkage = 0.1, minobspernode = 10, params = list(),
@@ -306,7 +307,7 @@ descr_SL.glmnet <- "elastic net with $\\lambda$ selected by 5-fold CV and $\\alp
 descr_SL.glmnet.50 <- paste0(descr_SL.glmnet, "0.5")
 descr_SL.glmnet.25 <- paste0(descr_SL.glmnet, "0.25")
 descr_SL.glmnet.75 <- paste0(descr_SL.glmnet, "0.75")
-descr_SL.glmnet.0 <- "elastic net with $\\lambda$ selected by CV and $\\alpha$ equal to 0"
+descr_SL.glmnet.0 <- paste0(descr_SL.glmnet, "1 (i.e., the lasso)")
 
 descr_SL.mean <- "intercept only regression"
 descr_SL.glm <- "main terms generalized linear model"

--- a/code/05_ml_var_importance_measures.R
+++ b/code/05_ml_var_importance_measures.R
@@ -1,6 +1,6 @@
 # A function that extracts importance measures for each feature
 # from a fitted super learner object. We get the best fitting ranger, xgboost,
-# and LASSO model from the library and extract importance features from those.
+# h2oboost, and/or LASSO model from the library and extract importance features from those.
 #' @param fit_sl the fitted regression function. If opts$learners is a single learner (e.g., xgboost),
 #' then this is an object with class equal to the class of that learner. If opts$learners has multiple learners,
 #' then this is a SuperLearner object.
@@ -39,6 +39,12 @@ extract_importance <- function(fit_sl, opts, ...){
         imp_dt <- data.frame(algo = "xgboost", Feature = xgboost_imp_dt_init$Feature,
                              rank = xgboost_imp_dt_init$rank,
                              Importance = xgboost_imp_dt_init$Feature)
+    }
+    if (any(grepl("H2O", class(fit_object)))) {
+        # get importance of best h2oboost
+        h2oboost_imp_dt_init <- fit_object@model$variable_importances
+        h2oboost_imp_dt_init$rank <- seq_len(nrow(h2oboost_imp_dt_init))
+        imp_dt <- data.frame(algo = "h2oboost", Feature = h2oboost_imp_dt_init$variable, rank = h2oboost_imp_dt_init$rank, Importance = h2oboost_imp_dt_init$relative_importance)
     }
     if ("cv.glmnet" %in% class(fit_object)) {
         # get importance of best glmnet

--- a/code/05_report.Rmd
+++ b/code/05_report.Rmd
@@ -723,7 +723,7 @@ Figure \@ref(fig:rocdichot1) shows the cross-validated ROC curve for predicting 
 ```{r roccap1, eval = ("sens1" %in% opts$outcomes) & (opts$cvperf) & ran_sl_dichot1}
 if(length(opts$learners) > 1){
   roc_cap <- paste0("Cross-validated ROC curve for the super learner, discrete super learner, and single best performing algorithm for predicting ", est_fillin, "sensitivity (n = ", ncomplete_sens, " observations).")
-}else if(!opts$cvtune & length(opts$var_tresh) == 1){
+}else if(!opts$cvtune & length(opts$var_thresh) == 1){
   roc_cap <- paste0("Cross-validated ROC curve for the specified learner for predicting ", est_fillin, "sensitivity (n = ", ncomplete_sens, " observations).")
 }else{
   roc_cap <- paste0("Cross-validated ROC curve for the learner (with tuning parameters ", ifelse(length(opts$var_thresh) == 1, "", "and optimal pre-screening level"), " selected via cross-validation) for predicting ", est_fillin, "sensitivity (n = ", ncomplete_sens, " observations).")
@@ -731,7 +731,7 @@ if(length(opts$learners) > 1){
 
 if(length(opts$learners) > 1){
   predprob_cap <- paste0("Cross-validated predicted probabilities of ", est_fillin, "sensitivity made by super learner, discrete super learner, and single best performing algorithm colored by cross-validation fold (n = ", ncomplete_sens, " observations).")
-}else if(!opts$cvtune & length(opts$var_tresh) == 1){
+}else if(!opts$cvtune & length(opts$var_thresh) == 1){
   predprob_cap <- paste0("Cross-validated predicted probabilities of ", est_fillin, "sensitivity made by the specified learner colored by cross-validation fold (n = ", ncomplete_sens, " observations).")
 }else{
   predprob_cap <- paste0("Cross-validated predicted probabilities of ", est_fillin, "sensitivity made by the cross-validation-tuned learner colored by cross-validation fold (n = ", ncomplete_sens, " observations).")
@@ -815,7 +815,7 @@ if ("figures" %in% opts$return) {
 
 `r if (!("sens1" %in% opts$outcomes) | (!("marg" %in% opts$importance_ind) & !("cond" %in% opts$importance_ind)) | !ran_vimp_dichot1) "-->"`
 
-`r if (!("sens1" %in% opts$outcomes) | !("pred" %in% opts$importance_ind) | !ran_vimp_dichot1) "<!--"`
+`r if (!("sens1" %in% opts$outcomes) | !("pred" %in% opts$importance_ind) | !ran_sl_dichot1) "<!--"`
 
 ### Predictive importance
 

--- a/docs/index.Rmd
+++ b/docs/index.Rmd
@@ -1,6 +1,6 @@
 ---
 title: "`slapnap`: Super LeArner Prediction of NAb Panels"
-author: "David Benkeser, Brian D. Williamson, Craig A. Magaret, Sohail Nizam, Peter B. Gilbert"
+author: "David Benkeser, Brian D. Williamson, Craig A. Magaret, Sohail Nizam, Courtney Simmons, Peter B. Gilbert"
 date: "`r format(Sys.time(), '%B %d, %Y')`"
 bibliography: refs.bib
 link-citations: true

--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -1,3 +1,11 @@
+@Manual{h2opkg,
+    title = {R Interface for H2O},
+    author = {H2O.ai},
+    year = {2016},
+    note = {R package version 3.10.0.8},
+    url = {https://github.com/h2oai/h2o-3}
+}
+
 @Manual{superlearnerpkg,
   title = {{SuperLearner}: Super Learner Prediction},
   author = {Eric Polley and Erin LeDell and Chris Kennedy and Mark {van der Laan}},

--- a/docs/slapnap_documentation.Rmd
+++ b/docs/slapnap_documentation.Rmd
@@ -56,7 +56,7 @@ __-e options for `slapnap`__
 * __`binary_outcomes`__ A string defining the measure of neutralization to use for defining binary outcomes. Possible values are `"ic50"` (the default, for using IC$_{50}$ to define sensitivity) or `"ic80"` (for using IC$_{80}$ to define sensitivity).
 * __`sens_thresh`__ A numeric value defining the neutralization threshold for defining a sensitive versus resistant pseudovirus (default = 1). The dichotomous sensitivity/resistant `outcome`s are defined as the indicator that (estimated) IC$_{50}$ (or IC$_{80}$, if `binary_outcomes="ic80"`) is greater than or equal to `sens_thresh`.
 * __`multsens_nab`__ A numeric value used for defining whether a pseudovirus is resistant to a multi-nAb cocktail. Only used if `multsens` is included in `outcome` and more than one `nab` is requested. The dichotomous `outcome` `multsens` is defined as the indicator that a virus has IC$_{50}$ (or IC$_{80}$, if `binary_outcomes="ic80"`) greater than `sens_thresh` for at least `multsens_nab` nAbs.
-* __`learners`__: A semicolon-separated string of machine learning algorithms to include in the analysis. Possible values include `"rf"` (random forest, default), `"xgboost"` (eXtreme gradient boosting), and `"lasso"` (elastic net). See Section \@ref(sec:learnerdetails) for details on how tuning parameters are chosen. If more than one algorithm is included, then it is assumed that a cross-validated-based ensemble (i.e., a super learner) is desired (see Section \@ref(sec:sldetails)).
+* __`learners`__: A semicolon-separated string of machine learning algorithms to include in the analysis. Possible values include `"rf"` (random forest, default), `"xgboost"` (eXtreme gradient boosting), `"h2oboost"` (gradient boosting using H2O.ai) and `"lasso"` (elastic net). See Section \@ref(sec:learnerdetails) for details on how tuning parameters are chosen. If more than one algorithm is included, then it is assumed that a cross-validated-based ensemble (i.e., a super learner) is desired (see Section \@ref(sec:sldetails)).
 * __`cvtune`__: A boolean string (i.e., either `"TRUE"` or `"FALSE"` [default]) indicating whether the `learners` should be tuned using cross validation and a small grid search. Defaults to `"FALSE"`. If multiple `learners` are specified, then the super learner ensemble includes three versions of each of the requested `learners` with different tuning parameters.
 * __`cvperf`__: A boolean string (i.e., either `"TRUE"` or `"FALSE"` [default]) indicating whether the `learners` performance should be evaluated using cross validation. If `cvtune="TRUE"` or `learners` includes multiple algorithms, then nested cross validation is used to evaluate the performance of the cross validation-selected best value of tuning parameters for the specified algorithm or the super learner, respectively.
 * __`var_thresh`__: A numeric string that defines a threshold for pre-screening features. If a single positive number, all binary features with fewer than `var_thresh` 0's or 1's are removed prior to the specified `learner` training. If several values are included in `var_thresh` and a single `learner` is specified, then cross-validation is used to select the optimal threshold. If multiple `learner`s are specified, then each `learner` is included in the super learner with pre-screening based on each value of `var_thresh`.
@@ -207,13 +207,15 @@ If multiple bnAbs are requested (i.e., the `nab` option is a semi-colon separate
 
 ## Learners {#sec:learnerdetails}
 
-There are three possible `learners` available in `slapnap`: random forests [@breiman2001], as implemented in the `R` package `ranger` [@rangerpkg]; elastic net [@zou2005] as implemented in `glmnet` [@glmnetpkg]; and boosted trees [@friedman2001; @chen2016] as implemented in `xgboost` [@xgboostpkg].
+There are three possible `learners` available in `slapnap`: random forests [@breiman2001], as implemented in the `R` package `ranger` [@rangerpkg]; elastic net [@zou2005] as implemented in `glmnet` [@glmnetpkg]; and boosted trees [@friedman2001; @chen2016] as implemented in either `xgboost` [@xgboostpkg] or `H2O.ai` [@h2opkg].
 
 For each `learner`, there is a `default` choice of tuning parameters that is implemented if `cvtune="FALSE"`. If instead `cvtune="TRUE"`, then there are several choices of tuning parameters that are evaluated using `nfold` cross validation, Table \@ref(tab:learners).
 
 ```{r learners, echo = FALSE}
 xgboost_names <- paste0("`xgboost", c("_default`", "_1`", "_2`", "_3`"))
 xgboost_descr <- paste0("maximum tree depth equal to ", c(4, 2, 6, 8))
+h2oboost_names <- paste0("`h2oboost_default`")
+h2oboost_descr <- paste0("`max_depth` in (2, 4, 5, 6), `learn_rate` in (.05, .1, .2), and `col_sample_rate` in (.1, .2, .3); optimal combination chosen via 5-fold CV")
 rf_names <- paste0("`rf", c("_default`", "_1`", "_2`"))
 rf_descr <- paste0("`mtry` equal to ", c("square root of number of predictors",
                                          "one-half times square root of number of predictors",
@@ -221,8 +223,8 @@ rf_descr <- paste0("`mtry` equal to ", c("square root of number of predictors",
 lasso_names <- paste0("`lasso", c("_default`", "_1`", "_2`", "_3`"))
 lasso_descr <- paste0("$\\lambda$ selected by 5-fold CV and $\\alpha$ equal to ", c(0, 0.25, 0.5, 0.75))
 
-descr_table <- data.frame("learner" = c(rf_names, xgboost_names, lasso_names),
-                          "Tuning parameters" = c(rf_descr, xgboost_descr, lasso_descr))
+descr_table <- data.frame("learner" = c(rf_names, xgboost_names, h2oboost_names, lasso_names),
+                          "Tuning parameters" = c(rf_descr, xgboost_descr, h2oboost_descr, lasso_descr))
 knitr::kable(descr_table,
              col.names = c("`learner`", "Tuning parameters"),
              caption = "Labels for `learners` in report and description of their respective tuning parameters")
@@ -231,7 +233,8 @@ knitr::kable(descr_table,
 Tuning parameters not mentioned in the table are set as follows:
 
 * `rf`: `num.trees = 500`, `min.node.size = 5` for continuous outcomes and `= 1` for binary outcomes;
-* `xgboost`: `nrounds = 1000`, `eta = 0.1`, `min_child_weight = 10`, objective = `binary:logistic` for binary outcomes and `objective=reg:squarederror` for continuous outcomes.
+* `xgboost`: `nrounds = 1000`, `eta = 0.1`, `min_child_weight = 10`, `objective = binary:logistic` for binary outcomes and `objective = reg:squarederror` for continuous outcomes.
+* `h2oboost`: `ntrees = 1000`; for binary outcomes, `distribution = "bernoulli"`, `balance_classes = TRUE`, `fold_assignment = "Stratified"`, `stopping_metric = "AUC"`, while for continuous outcomes, `distribution = "gaussian"`, `balance_classes = FALSE`, `fold_assignment = "AUTO"`, `stopping_metric = "MSE"`; and `max_after_balance_class_size = 5`, `stopping_rounds = 3`, `stopping_tolerance = 0.001`, `max_runtime_secs = 60`.
 
 ## Super learner {#sec:sldetails}
 
@@ -273,9 +276,10 @@ The raw `R` objects (saved as `.rds` files) containing the point estimates, conf
 
 * `rf`: the `impurity` importance from `ranger` [@rangerpkg] is returned. The impurity importance for a given feature is computed by taking a normalized sum of the decrease in impurity (i.e., Gini index for binary outcomes; mean squared-error for continuous outcomes) over all nodes in the forest at which a split on that feature has been conducted.
 * `xgboost`: the `gain` importance from `xgboost` [@xgboostpkg] is returned. Interpretation is essentially the same as for `rf`'s `impurity` importance.
+* `h2oboost`: the `gain` importance [@h2opkg] is returned. Interpretation is the same as for `xgboost`'s `gain` importance.
 * `lasso`: the absolute value of the estimated regression coefficient at the cross-validation-selected $\lambda$ is returned.
 
-Note that these importance measures each have important limitations: the `rf` and `xgboost` measures will tend to favor features with many levels, while the `lasso` variable importance will tend to favor features with few levels. Nevertheless, these commonly reported measures can provide some insight into how a given learner is making predictions.
+Note that these importance measures each have important limitations: the `rf` , `h2oboost`, and `xgboost` measures will tend to favor features with many levels, while the `lasso` variable importance will tend to favor features with few levels. Nevertheless, these commonly reported measures can provide some insight into how a given learner is making predictions.
 
 If multiple `learners` are used, and thus a super learner is constructed, then the importance measures for the `learner` with the highest weight in the super learner are reported.
 

--- a/docs/slapnap_documentation.Rmd
+++ b/docs/slapnap_documentation.Rmd
@@ -193,7 +193,7 @@ If a single bnAb or combination of bnAbs that are measured directly in the CATNA
 * `ic50` = $\mbox{log}_{10}(\mbox{IC}_{50})$, where IC$_{50}$ is the half maximal inhibitory concentration;
 * `ic80` = $\mbox{log}_{10}(\mbox{IC}_{80})$, where IC$_{80}$ is the 80% maximal inhibitory concentration;
 * `iip` = $(-1)\mbox{log}_{10}(1 - \mbox{IIP})$, where IIP [@shen2008dose, @wagh2016optimal] is the instantaneous inhibitory potential, computed as $$ \frac{10^m}{\mbox{IC$_{50}$}^m + 10^m} \ , $$ where $m = \mbox{log}_{10}(4) / (\mbox{log}_{10}(\mbox{IC}_{80}) - \mbox{log}_{10}(\mbox{IC}_{50}))$; and
-* `sens` = sensitivity: the binary indicator that IC$_{50}$ $<$ `sens_thresh`, the user-specified sensitivity threshold.
+* `sens` = sensitivity: the binary indicator that IC$_{x}$ $<$ `sens_thresh`, the user-specified sensitivity threshold. The value of $x$ is determined by `binary_outcomes`, which defaults to `"ic50"` (i.e., $x = 50$) but may be set to `"ic80"` (i.e., $x = 80$).
 
 ### Multiple bnAbs
 
@@ -202,8 +202,8 @@ If multiple bnAbs are requested (i.e., the `nab` option is a semi-colon separate
 * `ic50` = $\mbox{log}_{10}(\mbox{estimated IC}_{50})$, where estimated IC$_{50}$ is computed as follows: for $J$ bnAbs, $$ \mbox{estimated IC}_{50} = \left( \sum_{j=1}^J \mbox{IC}_{50,j}^{-1} \right)^{-1} \ , $$ where IC$_{50,j}$ denotes the measured IC$_{50}$ for antibody $j$ [@wagh2016optimal];
 * `ic80` = $\mbox{log}_{10}(\mbox{estimated IC}_{80})$, where estimated IC$_{80}$ is computed as follows: for $J$ bnAbs, $$ \mbox{estimated IC}_{80} = \left( \sum_{j=1}^J \mbox{IC}_{80,j}^{-1} \right)^{-1} \ , $$ where IC$_{80,j}$ denotes the measured IC$_{80}$ for antibody $j$ [@wagh2016optimal];
 * `iip` = $(-1)\mbox{log}_{10}(1 - \mbox{IIP})$, where IIP is computed as $$ \frac{10^m}{\mbox{estimated IC$_{50}$}^m + 10^m} \ , $$ where $m = \mbox{log}_{10}(4) / (\mbox{log}_{10}(\mbox{estimated  IC}_{80}) - \mbox{log}_{10}(\mbox{estimated  IC}_{50}))$; and
-* `estsens` = estimated sensitivity: the binary indicator that estimated IC$_{50}$ (defined above) is less than `sens_thresh`; and
-* `multsens` = multiple sensitivity: the binary indicator that measured IC$_{50}$ is less than the sensitivity threshold (`sens_thresh`) for a number of bnAbs defined by `multsens_nab`.
+* `estsens` = estimated sensitivity: the binary indicator that estimated IC$_{x}$ (defined above) is less than `sens_thresh` (where $x$ is determined by the value of `binary_outcomes`); and
+* `multsens` = multiple sensitivity: the binary indicator that measured IC$_{x}$ is less than the sensitivity threshold (`sens_thresh`) for a number of bnAbs defined by `multsens_nab` (where $x$ is determined by the value of `binary_outcomes`).
 
 ## Learners {#sec:learnerdetails}
 


### PR DESCRIPTION
Update the report so that the H2O learner has a valid description and can be used for predictive variable importance.

Example executive summaries: VRC01 with only h2oboost, 3BNC117 with h2oboost and lasso
![3bnc117_exec-summary_23Apr2021](https://user-images.githubusercontent.com/13205756/115914205-814dbc80-a426-11eb-9e56-e83d0422c829.png)
![vrc01_exec-summary_23Apr2021](https://user-images.githubusercontent.com/13205756/115914212-827ee980-a426-11eb-9d7f-bb228e7482c8.png)

Example predictive importance: VRC01 with only h2oboost, 3BNC117 with h2oboost and lasso (lasso has highest weight)
![3bnc117_pred-imp_23Apr2021](https://user-images.githubusercontent.com/13205756/115914209-827ee980-a426-11eb-8f33-c4419eeb39be.png)
![vrc01_pred-imp_23Apr2021](https://user-images.githubusercontent.com/13205756/115914214-83178000-a426-11eb-8404-0bcc1ea1c6c2.png)

Update the book so that H2O is described and referenced as a valid learner.

